### PR TITLE
feat: sync filters UI for issue #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to VaultSync are documented here.
 
 ---
 
+## [1.2.0] — 2026-05-09
+
+### Added
+
+- **Sync Filters per vault** — A new "Sync Filters" screen on each vault's detail page lets you toggle preset ignore-pattern groups in plain language: Workspace state, Trash, Git repository, macOS metadata (`.DS_Store`), Copilot index, and Obsidian app cache. No need to learn `.stignore` syntax to skip the obvious stuff.
+- **Vault scan with size figures** — When you open Sync Filters, VaultSync scans the folder for known heavy directories (`.git`, `.copilot-index`, `node_modules`, `.obsidian/cache`) and shows their actual size in MB and file count. "Git repository — 45.2 MB, 1,847 files" makes the choice concrete. Matches are aggregated across all vault subdirectories in multi-vault Obsidian-root setups.
+- **Always skip on this iPhone** — A new menu item in the conflict resolver lets you add the conflicting file's exact path to the folder's ignore list with one tap. The fastest way from "this file conflicts every time" to a permanent fix.
+- **First-run recommendation sheet** — On first opening a vault's detail screen, a sheet pre-checks the recommended presets (Workspace state + Trash) and any heavy folders the scan found. Done applies everything; Skip dismisses without changes. Shown once per vault.
+- **Custom patterns editor** — A section in Sync Filters for free-form `.stignore` patterns with swipe-to-delete and a footer link to the Syncthing pattern docs.
+- **Sync Filters localization** — All new strings translated to English, German, and Simplified Chinese.
+
+### Changed
+
+- **Default ignore patterns** — Now derived from the new `IgnorePreset.recommended` set (Workspace state + Trash) instead of being hardcoded. Existing vaults keep their current `.stignore` lines untouched; the new UI just shows the corresponding presets as already-active.
+
+---
+
 ## [1.1.0] — 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,19 +99,15 @@ VaultSync is also not a magic always-on Syncthing daemon for iOS. Apple’s back
 
 ---
 
-## What’s New — v1.1.0
+## What’s New — v1.2.0
 
-> **Calmer First Launch** — First-run onboarding is now a short 2-screen introduction. Setup itself happens on the VaultSync home screen, where the real device, vault, and sync controls already live.
+> **Sync Filters** — A new per-vault screen lets you toggle preset ignore-pattern groups in plain language: Workspace state, Trash, Git repository, macOS metadata, Copilot index, and Obsidian app cache. No `.stignore` syntax needed.
 >
-> **Setup Status in Settings** — The old setup guide is now a live status and troubleshooting view that highlights what is ready, what still needs attention, and where to fix it.
+> **Vault scan with size figures** — VaultSync scans your folder for heavy directories (`.git`, `.copilot-index`, `node_modules`, `.obsidian/cache`) and shows actual size in MB so you can decide what to skip.
 >
-> **Pending Shares Need Action** — A waiting vault offer no longer looks finished. Vault syncing is only marked ready once at least one vault is actually active.
+> **Always skip on this iPhone** — A one-tap menu item in the conflict resolver permanently excludes the conflicting file from this device.
 >
-> **Cleaner Settings** — The old discovery controls are gone, reducing noise in Settings while leaving discovery enabled by default.
->
-> **Localized Setup Flow** — The refreshed onboarding and setup-status copy is now available in English, German, and Simplified Chinese.
->
-> **iOS 18+** — VaultSync now supports iOS/iPadOS 18 and later.
+> **First-run recommendation sheet** — A friendly intro the first time you open a new vault, with sensible defaults pre-checked.
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
 

--- a/docs/sync-filters-ux.md
+++ b/docs/sync-filters-ux.md
@@ -1,9 +1,9 @@
 # Sync Filters — UX Spec
 
-> Status: **draft for review** (issue [#1](https://github.com/psimaker/vaultsync/issues/1))
+> Status: **implemented** (issue [#1](https://github.com/psimaker/vaultsync/issues/1), shipped in v1.2.0)
 > Last updated: 2026-05-09
 
-This document describes the planned UI for excluding files and folders from sync — the feature requested in issue #1 by @vitaly74. It exists so we can agree on the design *before* writing implementation code.
+This document is the design reference for the Sync Filters feature — the UI for excluding files and folders from sync requested in issue #1 by @vitaly74. It captures the rationale behind the layout, preset catalog, migration path, and multi-vault behavior; refer to it when extending or modifying the feature.
 
 ---
 
@@ -161,14 +161,12 @@ Avoiding:
 
 All new strings shipped in English, German, and Simplified Chinese (the existing three locales).
 
-## 10. Open questions for @vitaly74
+## 10. Future considerations
 
-Three things I'd love your input on before I start building:
+Items that were deliberately scoped out of v1.2.0 and may make sense as follow-ups based on real-world usage feedback:
 
-1. **Plugin caches** — you mentioned `.copilot-index` (already covered as its own preset). Are there other specific plugin caches you regularly run into on mobile? E.g. Dataview index, Templater compiled cache, etc. I'd rather ship 2–3 narrow presets than one "Plugin caches" toggle that does the wrong thing.
+1. **Per-plugin cache presets** — A "Plugin caches" umbrella toggle was rejected as too coarse (different plugins store caches in different places). Concrete narrow presets for common offenders (e.g. Dataview index, Templater compiled cache) could be added if usage data shows they're frequently desired.
 
-2. **Other heavy folders to auto-detect** — the vault scan currently looks for `.git`, `.copilot-index`, `node_modules`, and `.obsidian/cache`. What else have you seen eat space on a mobile vault?
+2. **Additional heavy folders for auto-detection** — The vault scan currently looks for `.git`, `.copilot-index`, `node_modules`, and `.obsidian/cache`. Extend `heavyDirCandidates` in `go/bridge/folderscan.go` if other large directories are commonly seen on mobile vaults.
 
-3. **Naming** — does "Sync Filters" feel right to you? An alternative I considered was "Skip on this iPhone" as the section title (more direct, less jargon), with "Filters" as a fallback. No strong opinion either way.
-
-Anything else missing? The whole point of doing this as a draft PR is to catch design issues before code lands.
+3. **Alternative section naming** — "Sync Filters" was chosen over "Skip on this iPhone" as the section title. Re-evaluate based on user feedback if the term proves unclear.

--- a/docs/sync-filters-ux.md
+++ b/docs/sync-filters-ux.md
@@ -63,7 +63,7 @@ Position is intentional: filters are configuration, sharing/rescan are actions. 
 Five sections, each rendered as a `List` section:
 
 1. **Recommended** — always visible. Workspace state + Trash, both ON by default for new vaults.
-2. **Found in this vault** — only renders when the vault scan returned results. Shows actual byte size + file count for each detected heavy folder. The most persuasive piece of UI.
+2. **Found in this vault** — only renders when the vault scan returned results. Shows actual byte size + file count for each detected heavy folder. The scanner checks both the sync folder root and one level deep (the typical "Obsidian root with vault subdirs" layout) and aggregates matches per pattern (e.g. ".git in 3 vaults — 127 MB total"). The most persuasive piece of UI.
 3. **Other presets** — every preset that isn't already in Recommended or Found.
 4. **Custom patterns** — anything in `.stignore` that isn't part of any preset. User can swipe-to-delete or add a new line.
 5. **Footer** — link to the Syncthing pattern docs for power users.
@@ -128,6 +128,12 @@ Tapping it adds the conflict's *exact relative path* to the folder's ignore list
 > "`'.obsidian/plugins/dataview/cache.db'` will no longer sync to this iPhone. You can undo this in Sync Filters."
 
 Reasoning behind exact-path (not smart-glob): predictable. The user knows exactly what they ignored. If they later want to widen to `*.cache.db` or `.obsidian/plugins/dataview/*`, they can do that in the editor.
+
+## 6.5 Multi-vault setups
+
+In typical Obsidian use, the sync folder is the **Obsidian root** and individual vaults live as subdirectories inside it. Pattern matching handles this transparently: Syncthing automatically expands every unanchored pattern (anything without a leading `/`) to also match at any depth, so `.git` covers both `Obsidian/.git` and `Obsidian/Vault1/.git`. No `**/` prefix is needed in the preset definitions.
+
+The vault scanner specifically descends one level into non-hidden subdirectories so that heavy folders inside vaults (e.g. `Obsidian/Personal/.git`, `Obsidian/Work/.git`) are detected and their sizes aggregated into a single "Found in this vault" entry per pattern.
 
 ## 7. Migration
 

--- a/docs/sync-filters-ux.md
+++ b/docs/sync-filters-ux.md
@@ -1,0 +1,168 @@
+# Sync Filters — UX Spec
+
+> Status: **draft for review** (issue [#1](https://github.com/psimaker/vaultsync/issues/1))
+> Last updated: 2026-05-09
+
+This document describes the planned UI for excluding files and folders from sync — the feature requested in issue #1 by @vitaly74. It exists so we can agree on the design *before* writing implementation code.
+
+---
+
+## 1. Why
+
+The Syncthing engine already supports per-folder ignore patterns via `.stignore` files. VaultSync's Go bridge already exposes them (`GetFolderIgnores`, `SetFolderIgnores`). What's missing is the **UI** — without it, users can't see, add, or remove patterns from inside the app.
+
+The goal isn't to expose raw Syncthing pattern syntax. The goal is **"keep this off my iPhone"** in plain language. Most users don't know what a glob pattern is, but they do know that `.git` is taking 45 MB and they don't need it on mobile.
+
+## 2. Where it lives
+
+Per-vault, on the existing vault detail screen. A new `Sync Filters` link appears in `vaultDetailView` between the Conflicts and Shared With sections:
+
+```
+Vault                    (name, path)
+Sync Status              (state, completion, errors)
+Conflicts                (when present)
+► Sync Filters           ← new
+Shared With              (devices)
+Rescan Vault
+```
+
+Position is intentional: filters are configuration, sharing/rescan are actions. Right after Conflicts means a user who just resolved a `workspace.json` conflict sees the link to "stop this from happening again" immediately below.
+
+## 3. The screen — `IgnorePatternsView`
+
+```
+┌─ Sync Filters — "My Vault" ─────────────┐
+│                                          │
+│  Recommended                             │
+│  ☑ Workspace state                       │
+│    Prevents sync conflicts on which     │
+│    notes were open.                      │
+│  ☑ Trash                                 │
+│    Files already deleted on other       │
+│    devices.                              │
+│                                          │
+│  Found in this vault                     │
+│  ☐ Git repository                        │
+│    45.2 MB — 1,847 files                 │
+│  ☐ Copilot index                         │
+│    12.8 MB — 4,219 files                 │
+│                                          │
+│  Other presets                           │
+│  ☐ macOS metadata                        │
+│  ☐ Obsidian app cache                    │
+│                                          │
+│  Custom patterns                         │
+│  *.tmp                                   │
+│  Drafts/                                 │
+│  [ Add pattern (e.g. *.tmp) ] [ Add ]    │
+│                                          │
+│  How filters work →                      │
+└─────────────────────────────────────────┘
+```
+
+Five sections, each rendered as a `List` section:
+
+1. **Recommended** — always visible. Workspace state + Trash, both ON by default for new vaults.
+2. **Found in this vault** — only renders when the vault scan returned results. Shows actual byte size + file count for each detected heavy folder. The most persuasive piece of UI.
+3. **Other presets** — every preset that isn't already in Recommended or Found.
+4. **Custom patterns** — anything in `.stignore` that isn't part of any preset. User can swipe-to-delete or add a new line.
+5. **Footer** — link to the Syncthing pattern docs for power users.
+
+All toggles write through to `.stignore` immediately. No save button.
+
+## 4. Preset catalog
+
+| ID | Label | Patterns | Default in sheet |
+|---|---|---|---|
+| `workspace` | Workspace state | `.obsidian/workspace.json`, `.obsidian/workspace-mobile.json` | **ON** |
+| `trash` | Trash | `.Trash` | **ON** |
+| `git` | Git repository | `.git` | OFF (auto-on if scan finds it) |
+| `macos` | macOS metadata | `.DS_Store`, `._*` | OFF |
+| `copilot` | Copilot index | `.copilot-index` | OFF (auto-on if scan finds it) |
+| `obsidianCache` | Obsidian app cache | `.obsidian/cache` | OFF |
+
+Two presets that the issue thread mentioned but I'm **not** including in the initial catalog:
+
+- **"Plugin caches"** as a single preset is too coarse. Different plugins store caches in different places (Dataview's `cache.db`, Copilot's `.copilot-index`, etc.). Bundling them all under one toggle either misses real caches or accidentally excludes plugin data the user wants. I'd rather ship specific presets per plugin than one fuzzy bucket.
+- **General `.gitignore` / `.gitattributes`** — these are tiny text files most users want to sync (config-like). The `git` preset only excludes the `.git/` directory itself.
+
+## 5. First-run recommendation sheet
+
+```
+┌─ Sync Filters ──────────────────────────┐
+│                              [Skip] [Done]│
+│                                          │
+│  Skip these on this iPhone? You can     │
+│  change this anytime in Sync Filters.    │
+│                                          │
+│  Recommended                             │
+│  ☑ Workspace state                       │
+│  ☑ Trash                                 │
+│                                          │
+│  Found in this vault                     │
+│  ☑ Git repository    45.2 MB             │
+│  ☑ Copilot index     12.8 MB             │
+│                                          │
+└─────────────────────────────────────────┘
+```
+
+Shown the **first time** a user opens a vault's detail screen, per vault. Persisted via a `UserDefaults` array of folder IDs that have been shown.
+
+- **Done** — applies the checked presets/patterns to `.stignore` and dismisses.
+- **Skip** — dismisses without changing `.stignore`. The folder is still marked as "seen", so the sheet won't reappear.
+- Detected heavy folders are pre-checked but the user can uncheck before applying.
+
+The Recommended set is also auto-applied silently when a new folder is added (so a fresh vault never syncs `workspace.json` even if the user instantly closes the sheet without tapping Done).
+
+## 6. Conflict → Ignore
+
+In `ConflictDiffView`, a new toolbar menu appears (top-right `⋯`):
+
+```
+⋯ menu
+└─ Always skip on this iPhone
+```
+
+Tapping it adds the conflict's *exact relative path* to the folder's ignore list. Then a confirmation alert:
+
+> "`'.obsidian/plugins/dataview/cache.db'` will no longer sync to this iPhone. You can undo this in Sync Filters."
+
+Reasoning behind exact-path (not smart-glob): predictable. The user knows exactly what they ignored. If they later want to widen to `*.cache.db` or `.obsidian/plugins/dataview/*`, they can do that in the editor.
+
+## 7. Migration
+
+For users updating from a current build:
+- The 3 silent default patterns (`.Trash`, `.obsidian/workspace.json`, `.obsidian/workspace-mobile.json`) **stay on disk untouched**.
+- The new derived state automatically shows "Workspace state" and "Trash" as ON.
+- No migration sheet. No disk changes. No surprise.
+
+For new vaults added after this lands:
+- Recommended presets are silently applied (same as before — keeps `workspace.json` from generating immediate conflicts).
+- The first-run sheet appears on first vault-detail open, with Recommended already checked and any scan results pre-checked.
+
+## 8. Naming
+
+Throughout the app:
+- Section title: **"Sync Filters"**
+- CTAs and copy: **"Skip on this iPhone"**, **"Always skip on this iPhone"**, **"Choose what gets synced to this iPhone"**
+
+Avoiding:
+- "Ignore patterns" — Syncthing-jargon, users don't think in patterns
+- "Exclusions" — corporate-y
+- "Filter rules" — too abstract
+
+## 9. Localization
+
+All new strings shipped in English, German, and Simplified Chinese (the existing three locales).
+
+## 10. Open questions for @vitaly74
+
+Three things I'd love your input on before I start building:
+
+1. **Plugin caches** — you mentioned `.copilot-index` (already covered as its own preset). Are there other specific plugin caches you regularly run into on mobile? E.g. Dataview index, Templater compiled cache, etc. I'd rather ship 2–3 narrow presets than one "Plugin caches" toggle that does the wrong thing.
+
+2. **Other heavy folders to auto-detect** — the vault scan currently looks for `.git`, `.copilot-index`, `node_modules`, and `.obsidian/cache`. What else have you seen eat space on a mobile vault?
+
+3. **Naming** — does "Sync Filters" feel right to you? An alternative I considered was "Skip on this iPhone" as the section title (more direct, less jargon), with "Filters" as a fallback. No strong opinion either way.
+
+Anything else missing? The whole point of doing this as a draft PR is to catch design issues before code lands.

--- a/go/bridge/folderscan.go
+++ b/go/bridge/folderscan.go
@@ -1,14 +1,20 @@
 // Folder scanner: detects known heavy directories in a vault to power
 // the "Found in this vault" section of the Sync Filters UI.
+//
+// In typical Obsidian setups the sync folder is the Obsidian root, and the
+// actual vaults are immediate subdirectories. The scanner therefore checks
+// both the top level and one level deep, aggregating matches per pattern.
 package bridge
 
 import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// DetectedPattern describes one heavy directory found in a vault.
+// DetectedPattern describes one heavy directory (or aggregate of multiple
+// matches) found in a vault.
 type DetectedPattern struct {
 	Pattern   string `json:"pattern"`
 	Label     string `json:"label"`
@@ -31,8 +37,13 @@ var heavyDirCandidates = []struct {
 	{".obsidian/cache", "Obsidian app cache"},
 }
 
-// ScanFolderForKnownPatterns walks a vault for known heavy directories
-// and returns size + file count per match as JSON.
+// ScanFolderForKnownPatterns walks a vault for known heavy directories and
+// returns aggregated size + file count per pattern as JSON.
+//
+// Search depth: the folder root, plus each non-hidden top-level subdirectory
+// (the "vault subdir" pattern). Matches in multiple locations are summed
+// into a single entry per pattern (e.g. ".git in 3 vaults — 127 MB total").
+//
 // Returns {"detected":[]} for unknown folders, missing paths, or empty vaults.
 func ScanFolderForKnownPatterns(folderID string) string {
 	folders := getFolderConfigs()
@@ -44,23 +55,57 @@ func ScanFolderForKnownPatterns(folderID string) string {
 		return `{"detected":[]}`
 	}
 
+	type accum struct {
+		label string
+		bytes int64
+		count int
+	}
+	sums := map[string]*accum{}
+
+	checkLocation := func(base string) {
+		for _, c := range heavyDirCandidates {
+			full := filepath.Join(base, c.Pattern)
+			info, err := os.Stat(full)
+			if err != nil || !info.IsDir() {
+				continue
+			}
+			size, count := dirSizeAndCount(full)
+			if count == 0 {
+				continue
+			}
+			if a, exists := sums[c.Pattern]; exists {
+				a.bytes += size
+				a.count += count
+			} else {
+				sums[c.Pattern] = &accum{label: c.Label, bytes: size, count: count}
+			}
+		}
+	}
+
+	// Top level (single-vault setups, or stray heavy folders next to the vaults).
+	checkLocation(folder.Path)
+
+	// One level deep — the typical "Obsidian root with vault subdirs" layout.
+	if entries, err := os.ReadDir(folder.Path); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			checkLocation(filepath.Join(folder.Path, entry.Name()))
+		}
+	}
+
+	// Emit in the order of heavyDirCandidates for stable output.
 	detected := []DetectedPattern{}
 	for _, c := range heavyDirCandidates {
-		full := filepath.Join(folder.Path, c.Pattern)
-		info, err := os.Stat(full)
-		if err != nil || !info.IsDir() {
-			continue
+		if a, exists := sums[c.Pattern]; exists {
+			detected = append(detected, DetectedPattern{
+				Pattern:   c.Pattern,
+				Label:     a.label,
+				SizeBytes: a.bytes,
+				FileCount: a.count,
+			})
 		}
-		size, count := dirSizeAndCount(full)
-		if count == 0 {
-			continue
-		}
-		detected = append(detected, DetectedPattern{
-			Pattern:   c.Pattern,
-			Label:     c.Label,
-			SizeBytes: size,
-			FileCount: count,
-		})
 	}
 
 	data, err := json.Marshal(ScanResult{Detected: detected})

--- a/go/bridge/folderscan.go
+++ b/go/bridge/folderscan.go
@@ -1,0 +1,87 @@
+// Folder scanner: detects known heavy directories in a vault to power
+// the "Found in this vault" section of the Sync Filters UI.
+package bridge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// DetectedPattern describes one heavy directory found in a vault.
+type DetectedPattern struct {
+	Pattern   string `json:"pattern"`
+	Label     string `json:"label"`
+	SizeBytes int64  `json:"sizeBytes"`
+	FileCount int    `json:"fileCount"`
+}
+
+// ScanResult is the JSON envelope returned by ScanFolderForKnownPatterns.
+type ScanResult struct {
+	Detected []DetectedPattern `json:"detected"`
+}
+
+var heavyDirCandidates = []struct {
+	Pattern string
+	Label   string
+}{
+	{".git", "Git repository"},
+	{".copilot-index", "Copilot index"},
+	{"node_modules", "Node modules"},
+	{".obsidian/cache", "Obsidian app cache"},
+}
+
+// ScanFolderForKnownPatterns walks a vault for known heavy directories
+// and returns size + file count per match as JSON.
+// Returns {"detected":[]} for unknown folders, missing paths, or empty vaults.
+func ScanFolderForKnownPatterns(folderID string) string {
+	folders := getFolderConfigs()
+	if folders == nil {
+		return `{"detected":[]}`
+	}
+	folder, ok := folders[folderID]
+	if !ok {
+		return `{"detected":[]}`
+	}
+
+	detected := []DetectedPattern{}
+	for _, c := range heavyDirCandidates {
+		full := filepath.Join(folder.Path, c.Pattern)
+		info, err := os.Stat(full)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		size, count := dirSizeAndCount(full)
+		if count == 0 {
+			continue
+		}
+		detected = append(detected, DetectedPattern{
+			Pattern:   c.Pattern,
+			Label:     c.Label,
+			SizeBytes: size,
+			FileCount: count,
+		})
+	}
+
+	data, err := json.Marshal(ScanResult{Detected: detected})
+	if err != nil {
+		return `{"detected":[]}`
+	}
+	return string(data)
+}
+
+func dirSizeAndCount(root string) (int64, int) {
+	var total int64
+	var count int
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !info.IsDir() {
+			total += info.Size()
+			count++
+		}
+		return nil
+	})
+	return total, count
+}

--- a/go/bridge/folderscan_test.go
+++ b/go/bridge/folderscan_test.go
@@ -1,0 +1,152 @@
+package bridge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestScanFolderForKnownPatternsDetectsGitDirectory(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	vault := t.TempDir()
+	gitDir := filepath.Join(vault, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		t.Fatalf("write HEAD: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("[core]\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	folderID := "scan-git"
+	if errMsg := AddFolder(folderID, "Scan Git", vault); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	var result ScanResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("unmarshal failed: %v (raw=%s)", err, raw)
+	}
+	if len(result.Detected) != 1 {
+		t.Fatalf("expected 1 detected pattern, got %d (raw=%s)", len(result.Detected), raw)
+	}
+	got := result.Detected[0]
+	if got.Pattern != ".git" {
+		t.Errorf("pattern = %q, want .git", got.Pattern)
+	}
+	if got.Label != "Git repository" {
+		t.Errorf("label = %q, want Git repository", got.Label)
+	}
+	if got.FileCount != 2 {
+		t.Errorf("fileCount = %d, want 2", got.FileCount)
+	}
+	if got.SizeBytes <= 0 {
+		t.Errorf("sizeBytes = %d, want > 0", got.SizeBytes)
+	}
+}
+
+func TestScanFolderForKnownPatternsEmptyVault(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	vault := t.TempDir()
+	folderID := "scan-empty"
+	if errMsg := AddFolder(folderID, "Empty", vault); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	if raw != `{"detected":[]}` {
+		t.Errorf("got %q, want empty detected list", raw)
+	}
+}
+
+func TestScanFolderForKnownPatternsUnknownFolderID(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	raw := ScanFolderForKnownPatterns("does-not-exist")
+	if raw != `{"detected":[]}` {
+		t.Errorf("got %q, want empty detected list", raw)
+	}
+}
+
+func TestScanFolderForKnownPatternsMultipleCandidates(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	vault := t.TempDir()
+	for _, dir := range []string{".git", ".copilot-index", "node_modules"} {
+		full := filepath.Join(vault, dir)
+		if err := os.MkdirAll(full, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(full, "marker"), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write marker in %s: %v", dir, err)
+		}
+	}
+
+	folderID := "scan-multi"
+	if errMsg := AddFolder(folderID, "Multi", vault); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	var result ScanResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(result.Detected) != 3 {
+		t.Fatalf("expected 3 detected, got %d (raw=%s)", len(result.Detected), raw)
+	}
+	patterns := map[string]bool{}
+	for _, d := range result.Detected {
+		patterns[d.Pattern] = true
+	}
+	for _, want := range []string{".git", ".copilot-index", "node_modules"} {
+		if !patterns[want] {
+			t.Errorf("missing detected pattern %q", want)
+		}
+	}
+}
+
+func TestScanFolderForKnownPatternsIgnoresEmptyDirectories(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	vault := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(vault, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	folderID := "scan-empty-git"
+	if errMsg := AddFolder(folderID, "Empty Git", vault); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	if raw != `{"detected":[]}` {
+		t.Errorf("expected empty list for dir with no files, got %q", raw)
+	}
+}

--- a/go/bridge/folderscan_test.go
+++ b/go/bridge/folderscan_test.go
@@ -128,6 +128,113 @@ func TestScanFolderForKnownPatternsMultipleCandidates(t *testing.T) {
 	}
 }
 
+func TestScanFolderForKnownPatternsAggregatesNestedVaults(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	// Mimic the typical Obsidian setup: a sync folder that is the Obsidian
+	// root, with each vault as an immediate subdirectory.
+	root := t.TempDir()
+	for _, vault := range []string{"Personal", "Work"} {
+		gitDir := filepath.Join(root, vault, ".git")
+		if err := os.MkdirAll(gitDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", gitDir, err)
+		}
+		// Two files per .git so total FileCount = 4.
+		if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+			t.Fatalf("write HEAD in %s: %v", vault, err)
+		}
+		if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("[core]\n"), 0o644); err != nil {
+			t.Fatalf("write config in %s: %v", vault, err)
+		}
+	}
+	// One vault also has a Copilot index — should appear as its own entry.
+	copilotDir := filepath.Join(root, "Personal", ".copilot-index")
+	if err := os.MkdirAll(copilotDir, 0o755); err != nil {
+		t.Fatalf("mkdir copilot: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(copilotDir, "shard"), []byte("xx"), 0o644); err != nil {
+		t.Fatalf("write copilot: %v", err)
+	}
+
+	folderID := "scan-nested"
+	if errMsg := AddFolder(folderID, "Nested", root); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	var result ScanResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("unmarshal failed: %v (raw=%s)", err, raw)
+	}
+
+	byPattern := map[string]DetectedPattern{}
+	for _, d := range result.Detected {
+		byPattern[d.Pattern] = d
+	}
+
+	git, ok := byPattern[".git"]
+	if !ok {
+		t.Fatalf("expected .git entry in detected (raw=%s)", raw)
+	}
+	if git.FileCount != 4 {
+		t.Errorf(".git fileCount = %d, want 4 (aggregated across 2 vaults)", git.FileCount)
+	}
+	if git.SizeBytes <= 0 {
+		t.Errorf(".git sizeBytes = %d, want > 0", git.SizeBytes)
+	}
+
+	copilot, ok := byPattern[".copilot-index"]
+	if !ok {
+		t.Fatalf("expected .copilot-index entry in detected (raw=%s)", raw)
+	}
+	if copilot.FileCount != 1 {
+		t.Errorf(".copilot-index fileCount = %d, want 1", copilot.FileCount)
+	}
+}
+
+func TestScanFolderForKnownPatternsSkipsHiddenSubdirs(t *testing.T) {
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	// A hidden top-level dir (e.g. .obsidian) should not be descended into;
+	// its candidates would otherwise be double-counted.
+	root := t.TempDir()
+	cacheDir := filepath.Join(root, ".obsidian", "cache")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "blob"), []byte("xx"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	folderID := "scan-hidden"
+	if errMsg := AddFolder(folderID, "Hidden", root); errMsg != "" {
+		t.Fatalf("AddFolder: %s", errMsg)
+	}
+
+	raw := ScanFolderForKnownPatterns(folderID)
+	var result ScanResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if len(result.Detected) != 1 {
+		t.Fatalf("expected 1 detected pattern, got %d (raw=%s)", len(result.Detected), raw)
+	}
+	if result.Detected[0].Pattern != ".obsidian/cache" {
+		t.Errorf("pattern = %q, want .obsidian/cache", result.Detected[0].Pattern)
+	}
+	if result.Detected[0].FileCount != 1 {
+		t.Errorf("fileCount = %d, want 1 (no double-counting)", result.Detected[0].FileCount)
+	}
+}
+
 func TestScanFolderForKnownPatternsIgnoresEmptyDirectories(t *testing.T) {
 	configDir := testConfigDir(t)
 	if errMsg := StartSyncthing(configDir); errMsg != "" {

--- a/ios/VaultSync/Models/DetectedPattern.swift
+++ b/ios/VaultSync/Models/DetectedPattern.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Mirror of the Go bridge's `DetectedPattern` JSON.
+/// Surfaced in the Sync Filters UI's "Found in this vault" section.
+struct DetectedPattern: Codable, Identifiable, Sendable, Hashable {
+    let pattern: String
+    let label: String
+    let sizeBytes: Int64
+    let fileCount: Int
+
+    var id: String { pattern }
+}
+
+struct DetectedScan: Codable, Sendable {
+    let detected: [DetectedPattern]
+}

--- a/ios/VaultSync/Models/IgnorePreset.swift
+++ b/ios/VaultSync/Models/IgnorePreset.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// A named group of `.stignore` patterns surfaced as a single toggle in the
+/// Sync Filters UI. The label/description are L10n keys (English-sentence form,
+/// matching the existing Localizable.strings convention).
+struct IgnorePreset: Identifiable, Sendable, Hashable {
+    let id: String
+    let label: String
+    let description: String
+    let patterns: [String]
+}
+
+extension IgnorePreset {
+    static let workspace = IgnorePreset(
+        id: "workspace",
+        label: "Workspace state",
+        description: "Prevents sync conflicts on which notes were open.",
+        patterns: [".obsidian/workspace.json", ".obsidian/workspace-mobile.json"]
+    )
+
+    static let trash = IgnorePreset(
+        id: "trash",
+        label: "Trash",
+        description: "Files already deleted on other devices.",
+        patterns: [".Trash"]
+    )
+
+    static let git = IgnorePreset(
+        id: "git",
+        label: "Git repository",
+        description: "Version history — rarely useful on iPhone.",
+        patterns: [".git"]
+    )
+
+    static let macos = IgnorePreset(
+        id: "macos",
+        label: "macOS metadata",
+        description: "Finder metadata files like .DS_Store.",
+        patterns: [".DS_Store", "._*"]
+    )
+
+    static let copilot = IgnorePreset(
+        id: "copilot",
+        label: "Copilot index",
+        description: "Cache of Obsidian Copilot, regenerated automatically.",
+        patterns: [".copilot-index"]
+    )
+
+    static let obsidianCache = IgnorePreset(
+        id: "obsidianCache",
+        label: "Obsidian app cache",
+        description: "Auto-regenerated Obsidian internal cache.",
+        patterns: [".obsidian/cache"]
+    )
+
+    /// Pre-checked in the first-run sheet for new vaults.
+    static let recommended: [IgnorePreset] = [.workspace, .trash]
+
+    /// Order shown in `IgnorePatternsView` under "Other presets".
+    static let all: [IgnorePreset] = [
+        .workspace, .trash, .git, .macos, .copilot, .obsidianCache,
+    ]
+
+    /// Map a detected scan pattern (e.g. ".git") back to its preset, if any.
+    static func preset(forDetectedPattern pattern: String) -> IgnorePreset? {
+        all.first { $0.patterns.contains(pattern) }
+    }
+}

--- a/ios/VaultSync/Services/SyncBridgeService.swift
+++ b/ios/VaultSync/Services/SyncBridgeService.swift
@@ -176,6 +176,12 @@ struct SyncBridgeService {
         return result.isEmpty ? nil : result
     }
 
+    /// Scan a folder for known heavy directories (.git, .copilot-index, etc.).
+    /// Returns a JSON envelope; decode with `DetectedScan`.
+    static func scanFolderForKnownPatterns(folderID: String) -> String {
+        BridgeScanFolderForKnownPatterns(folderID)
+    }
+
     // MARK: - Phase 6: Conflict management
 
     /// Get all conflict files in a folder as JSON.

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -76,13 +76,13 @@ final class SyncthingManager {
     private static let maxSyncActivityItems = 120
     private static let maxFileEventsPerFolderPerPoll = 6
 
-    /// Default .stignore patterns for Obsidian vaults to prevent sync conflicts
-    /// on device-specific files.
-    private static let defaultIgnorePatterns = [
-        ".Trash",
-        ".obsidian/workspace.json",
-        ".obsidian/workspace-mobile.json",
-    ]
+    /// Default `.stignore` patterns auto-applied to NEW folders.
+    /// Derived from `IgnorePreset.recommended` so the catalog stays in sync.
+    /// Existing folders keep whatever they have; the first-run recommendation
+    /// sheet on first vault-detail open lets users review and extend.
+    private static var defaultIgnorePatterns: [String] {
+        IgnorePreset.recommended.flatMap(\.patterns)
+    }
 
     private var hasAppliedStartupIgnores = false
     private var activeWidgetSyncStart: Date?
@@ -1477,5 +1477,86 @@ final class SyncthingManager {
             return []
         }
         return Set(values)
+    }
+
+    // MARK: - Sync Filters (Ignore Patterns)
+
+    private static let recommendationSheetShownKey = "syncthing.recommendationSheetShownFolders"
+
+    /// Read current `.stignore` lines for a folder.
+    func ignorePatterns(folderID: String) -> [String] {
+        let raw = SyncBridgeService.getFolderIgnores(folderID: folderID)
+        guard let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return []
+        }
+        return decoded
+    }
+
+    /// Replace all `.stignore` lines for a folder.
+    @discardableResult
+    func setIgnorePatterns(folderID: String, patterns: [String]) -> SyncUserError? {
+        guard let data = try? JSONEncoder().encode(patterns),
+              let json = String(data: data, encoding: .utf8) else {
+            return SyncUserError.from(rawMessage: "encoding ignore patterns failed")
+        }
+        if let err = SyncBridgeService.setFolderIgnores(folderID: folderID, ignoresJSON: json) {
+            return SyncUserError.from(rawMessage: err)
+        }
+        return nil
+    }
+
+    /// True iff every pattern in the preset is currently in the folder's `.stignore`.
+    func isPresetActive(_ preset: IgnorePreset, folderID: String) -> Bool {
+        let current = Set(ignorePatterns(folderID: folderID))
+        return preset.patterns.allSatisfy { current.contains($0) }
+    }
+
+    /// Atomically add or remove a preset's patterns from `.stignore`.
+    @discardableResult
+    func togglePreset(_ preset: IgnorePreset, folderID: String, enabled: Bool) -> SyncUserError? {
+        var current = ignorePatterns(folderID: folderID)
+        let presetSet = Set(preset.patterns)
+        if enabled {
+            for pattern in preset.patterns where !current.contains(pattern) {
+                current.append(pattern)
+            }
+        } else {
+            current.removeAll { presetSet.contains($0) }
+        }
+        return setIgnorePatterns(folderID: folderID, patterns: current)
+    }
+
+    /// Add a single pattern (e.g. exact relPath from a conflict). No-op if already present.
+    @discardableResult
+    func addIgnorePattern(_ pattern: String, folderID: String) -> SyncUserError? {
+        var current = ignorePatterns(folderID: folderID)
+        guard !current.contains(pattern) else { return nil }
+        current.append(pattern)
+        return setIgnorePatterns(folderID: folderID, patterns: current)
+    }
+
+    /// Run the Go-side scanner for known heavy directories.
+    /// `nonisolated static` so views can dispatch it on a detached Task without
+    /// blocking the main actor.
+    nonisolated static func scanFolderForKnownPatterns(folderID: String) -> [DetectedPattern] {
+        let raw = SyncBridgeService.scanFolderForKnownPatterns(folderID: folderID)
+        guard let data = raw.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(DetectedScan.self, from: data) else {
+            return []
+        }
+        return decoded.detected
+    }
+
+    func hasShownRecommendationSheet(folderID: String) -> Bool {
+        let shown = UserDefaults.standard.array(forKey: Self.recommendationSheetShownKey) as? [String] ?? []
+        return shown.contains(folderID)
+    }
+
+    func markRecommendationSheetShown(folderID: String) {
+        var shown = UserDefaults.standard.array(forKey: Self.recommendationSheetShownKey) as? [String] ?? []
+        guard !shown.contains(folderID) else { return }
+        shown.append(folderID)
+        UserDefaults.standard.set(shown, forKey: Self.recommendationSheetShownKey)
     }
 }

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -76,13 +76,17 @@ final class SyncthingManager {
     private static let maxSyncActivityItems = 120
     private static let maxFileEventsPerFolderPerPoll = 6
 
-    /// Default `.stignore` patterns auto-applied to NEW folders.
-    /// Derived from `IgnorePreset.recommended` so the catalog stays in sync.
-    /// Existing folders keep whatever they have; the first-run recommendation
-    /// sheet on first vault-detail open lets users review and extend.
-    private static var defaultIgnorePatterns: [String] {
-        IgnorePreset.recommended.flatMap(\.patterns)
-    }
+    /// Migration-safe silent auto-apply patterns. Hard-coded to the historical
+    /// set so future changes to `IgnorePreset.recommended` (which can grow or
+    /// shrink over time) do not silently mutate `.stignore` on existing vaults
+    /// during startup auto-merge. The first-run recommendation sheet uses
+    /// `IgnorePreset.recommended` separately for UI defaults — see
+    /// `SyncFilterRecommendationSheet`.
+    private static let defaultIgnorePatterns: [String] = [
+        ".Trash",
+        ".obsidian/workspace.json",
+        ".obsidian/workspace-mobile.json",
+    ]
 
     private var hasAppliedStartupIgnores = false
     private var activeWidgetSyncStart: Date?

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -1487,14 +1487,29 @@ final class SyncthingManager {
 
     private static let recommendationSheetShownKey = "syncthing.recommendationSheetShownFolders"
 
-    /// Read current `.stignore` lines for a folder.
-    func ignorePatterns(folderID: String) -> [String] {
+    /// Read current `.stignore` lines, distinguishing "no patterns yet" from
+    /// "could not parse bridge output". Returns nil only on decode failure.
+    /// Used internally by every read-modify-write flow so a malformed bridge
+    /// response can never silently cause `.stignore` to be overwritten with
+    /// an empty list (CodeRabbit data-loss guard).
+    private func readIgnorePatternsOrNil(folderID: String) -> [String]? {
         let raw = SyncBridgeService.getFolderIgnores(folderID: folderID)
         guard let data = raw.data(using: .utf8),
               let decoded = try? JSONDecoder().decode([String].self, from: data) else {
-            return []
+            return nil
         }
         return decoded
+    }
+
+    private func unreadableFiltersError() -> SyncUserError {
+        SyncUserError.from(rawMessage: L10n.tr("Could not read current sync filters. Please try again."))
+    }
+
+    /// Read current `.stignore` lines for a folder. Display-friendly: returns
+    /// an empty list if the bridge response cannot be parsed. Read-modify-write
+    /// flows must use `readIgnorePatternsOrNil` instead.
+    func ignorePatterns(folderID: String) -> [String] {
+        readIgnorePatternsOrNil(folderID: folderID) ?? []
     }
 
     /// Replace all `.stignore` lines for a folder.
@@ -1516,10 +1531,14 @@ final class SyncthingManager {
         return preset.patterns.allSatisfy { current.contains($0) }
     }
 
-    /// Atomically add or remove a preset's patterns from `.stignore`.
+    /// Atomically add or remove a preset's patterns from `.stignore`. Aborts
+    /// without writing if the current `.stignore` cannot be parsed, so an
+    /// unreadable bridge response can never wipe existing rules.
     @discardableResult
     func togglePreset(_ preset: IgnorePreset, folderID: String, enabled: Bool) -> SyncUserError? {
-        var current = ignorePatterns(folderID: folderID)
+        guard var current = readIgnorePatternsOrNil(folderID: folderID) else {
+            return unreadableFiltersError()
+        }
         let presetSet = Set(preset.patterns)
         if enabled {
             for pattern in preset.patterns where !current.contains(pattern) {
@@ -1531,13 +1550,48 @@ final class SyncthingManager {
         return setIgnorePatterns(folderID: folderID, patterns: current)
     }
 
-    /// Add a single pattern (e.g. exact relPath from a conflict). No-op if already present.
+    /// Add a single pattern (e.g. exact relPath from a conflict). No-op if
+    /// already present. Aborts without writing if the current `.stignore`
+    /// cannot be parsed.
     @discardableResult
     func addIgnorePattern(_ pattern: String, folderID: String) -> SyncUserError? {
-        var current = ignorePatterns(folderID: folderID)
+        guard var current = readIgnorePatternsOrNil(folderID: folderID) else {
+            return unreadableFiltersError()
+        }
         guard !current.contains(pattern) else { return nil }
         current.append(pattern)
         return setIgnorePatterns(folderID: folderID, patterns: current)
+    }
+
+    /// Apply a target set of preset toggles and detected-pattern toggles to
+    /// `.stignore`. Sheet-managed entries (preset patterns + the given
+    /// detected items) are removed first, then re-added only if currently
+    /// enabled, so deselecting actually takes effect. Custom patterns the
+    /// user added previously are preserved. Aborts without writing if the
+    /// current `.stignore` cannot be parsed.
+    @discardableResult
+    func applyRecommendedFilters(
+        folderID: String,
+        enabledPresetIDs: Set<String>,
+        detectedPatterns: [String],
+        enabledDetectedPatterns: Set<String>
+    ) -> SyncUserError? {
+        guard let existing = readIgnorePatternsOrNil(folderID: folderID) else {
+            return unreadableFiltersError()
+        }
+        let managed = Set(IgnorePreset.all.flatMap(\.patterns))
+            .union(detectedPatterns)
+        var patterns = existing.filter { !managed.contains($0) }
+
+        for preset in IgnorePreset.all where enabledPresetIDs.contains(preset.id) {
+            for pattern in preset.patterns where !patterns.contains(pattern) {
+                patterns.append(pattern)
+            }
+        }
+        for pattern in enabledDetectedPatterns where !patterns.contains(pattern) {
+            patterns.append(pattern)
+        }
+        return setIgnorePatterns(folderID: folderID, patterns: patterns)
     }
 
     /// Run the Go-side scanner for known heavy directories.

--- a/ios/VaultSync/Views/ConflictDiffView.swift
+++ b/ios/VaultSync/Views/ConflictDiffView.swift
@@ -20,7 +20,12 @@ struct ConflictDiffView: View {
     // Result summary flow
     @State private var resultSummaryMessage = ""
     @State private var showResultSummary = false
-    
+
+    // Always-skip flow
+    @State private var showSkipConfirmation = false
+    @State private var skipErrorMessage: String?
+    @State private var showSkipError = false
+
     @Environment(\.dismiss) private var dismiss
     
     enum ResolveAction {
@@ -89,6 +94,19 @@ struct ConflictDiffView: View {
         .navigationTitle("Resolve Conflict")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button {
+                        skipThisFile()
+                    } label: {
+                        Label(L10n.tr("Always skip on this iPhone"),
+                              systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                        .accessibilityLabel(L10n.tr("More actions"))
+                }
+            }
             ToolbarItemGroup(placement: .bottomBar) {
                 Button {
                     confirmAction(.keepThis)
@@ -159,9 +177,29 @@ struct ConflictDiffView: View {
         } message: {
             Text(resultSummaryMessage)
         }
+        .alert(L10n.tr("Skipping enabled"), isPresented: $showSkipConfirmation) {
+            Button("OK") { showSkipConfirmation = false }
+        } message: {
+            Text(L10n.fmt("'%@' will no longer sync to this iPhone. You can undo this in Sync Filters.",
+                          conflict.originalPath))
+        }
+        .alert(L10n.tr("Could not add filter"), isPresented: $showSkipError) {
+            Button("OK") { showSkipError = false }
+        } message: {
+            Text(skipErrorMessage ?? "")
+        }
         .task {
             await loadContent()
         }
+    }
+
+    private func skipThisFile() {
+        if let err = syncthingManager.addIgnorePattern(conflict.originalPath, folderID: folderID) {
+            skipErrorMessage = err.message
+            showSkipError = true
+            return
+        }
+        showSkipConfirmation = true
     }
 
     private func fileSection(title: String, icon: String, content: String) -> some View {

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     @State private var pendingShareFailures: [String: SyncUserError] = [:]
     @State private var pendingShareInFlight: Set<String> = []
     @State private var isRescanning = false
+    @State private var pendingFilterSheetFolder: SyncthingManager.FolderInfo?
 
     private let slate = Color(red: 38 / 255, green: 50 / 255, blue: 56 / 255)
     private let teal = Color(red: 0 / 255, green: 137 / 255, blue: 123 / 255)
@@ -598,6 +599,19 @@ struct ContentView: View {
                 }
             }
 
+            Section {
+                NavigationLink {
+                    IgnorePatternsView(
+                        folderID: folder.id,
+                        folderLabel: folder.label.isEmpty ? folder.id : folder.label,
+                        syncthingManager: syncthingManager
+                    )
+                } label: {
+                    Label(L10n.tr("Sync Filters"), systemImage: "line.3.horizontal.decrease.circle")
+                }
+                .accessibilityHint(L10n.tr("Choose what gets synced to this iPhone"))
+            }
+
             Section("Shared With") {
                 ForEach(syncthingManager.devices) { device in
                     let isShared = folder.deviceIDs.contains(device.deviceID)
@@ -663,6 +677,18 @@ struct ContentView: View {
         }
         .navigationTitle(folder.label.isEmpty ? folder.id : folder.label)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            if !syncthingManager.hasShownRecommendationSheet(folderID: folder.id) {
+                pendingFilterSheetFolder = folder
+            }
+        }
+        .sheet(item: $pendingFilterSheetFolder) { folder in
+            SyncFilterRecommendationSheet(
+                folderID: folder.id,
+                folderLabel: folder.label.isEmpty ? folder.id : folder.label,
+                syncthingManager: syncthingManager
+            )
+        }
     }
 
     private func toggleDeviceSharing(folderID: String, deviceID: String, isShared: Bool) {

--- a/ios/VaultSync/Views/IgnorePatternsView.swift
+++ b/ios/VaultSync/Views/IgnorePatternsView.swift
@@ -1,0 +1,222 @@
+import SwiftUI
+
+struct IgnorePatternsView: View {
+    let folderID: String
+    let folderLabel: String
+    let syncthingManager: SyncthingManager
+
+    @State private var ignoredPatterns: Set<String> = []
+    @State private var detected: [DetectedPattern] = []
+    @State private var newPattern: String = ""
+    @State private var alertMessage: String?
+    @State private var hasLoadedScan = false
+
+    var body: some View {
+        List {
+            recommendedSection
+            if !detected.isEmpty {
+                foundSection
+            }
+            otherPresetsSection
+            customSection
+            footerSection
+        }
+        .navigationTitle(L10n.tr("Sync Filters"))
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await initialLoad() }
+        .alert(L10n.tr("Sync Filter Error"), isPresented: errorBinding) {
+            Button(L10n.tr("OK")) { alertMessage = nil }
+        } message: { Text(alertMessage ?? "") }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(get: { alertMessage != nil }, set: { if !$0 { alertMessage = nil } })
+    }
+
+    private var recommendedSection: some View {
+        Section(header: Text(L10n.tr("Recommended"))) {
+            ForEach(IgnorePreset.recommended) { preset in
+                presetRow(preset)
+            }
+        }
+    }
+
+    private var foundSection: some View {
+        Section(header: Text(L10n.tr("Found in this vault"))) {
+            ForEach(detected) { item in
+                if let preset = IgnorePreset.preset(forDetectedPattern: item.pattern) {
+                    presetRow(preset, sizeOverride: item)
+                } else {
+                    Toggle(isOn: detectedToggleBinding(for: item)) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(L10n.tr(item.label)).font(.body)
+                            Text(formattedSize(item))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var otherPresetsSection: some View {
+        let recommendedIDs = Set(IgnorePreset.recommended.map(\.id))
+        let detectedIDs = Set(detected.compactMap {
+            IgnorePreset.preset(forDetectedPattern: $0.pattern)?.id
+        })
+        let others = IgnorePreset.all.filter {
+            !recommendedIDs.contains($0.id) && !detectedIDs.contains($0.id)
+        }
+        return Section(header: Text(L10n.tr("Other presets"))) {
+            ForEach(others) { preset in
+                presetRow(preset)
+            }
+        }
+    }
+
+    private var customSection: some View {
+        Section(header: Text(L10n.tr("Custom patterns"))) {
+            ForEach(customPatterns, id: \.self) { pattern in
+                Text(pattern).font(.system(.body, design: .monospaced))
+            }
+            .onDelete(perform: deleteCustom)
+
+            HStack {
+                TextField(L10n.tr("Add pattern (e.g. *.tmp)"), text: $newPattern)
+                    .font(.system(.body, design: .monospaced))
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                Button(L10n.tr("Add")) { addCustom() }
+                    .disabled(newPattern.trimmingCharacters(in: .whitespaces).isEmpty)
+            }
+        }
+    }
+
+    private var footerSection: some View {
+        Section {
+            Link(L10n.tr("How filters work"),
+                 destination: URL(string: "https://docs.syncthing.net/users/ignoring.html")!)
+        }
+    }
+
+    // MARK: - Derived state
+
+    private var customPatterns: [String] {
+        let presetPatterns = Set(IgnorePreset.all.flatMap(\.patterns))
+        return ignoredPatterns
+            .filter { !presetPatterns.contains($0) }
+            .sorted()
+    }
+
+    private func isActive(_ preset: IgnorePreset) -> Bool {
+        preset.patterns.allSatisfy { ignoredPatterns.contains($0) }
+    }
+
+    // MARK: - Rows
+
+    private func presetRow(_ preset: IgnorePreset, sizeOverride: DetectedPattern? = nil) -> some View {
+        Toggle(isOn: bindingFor(preset)) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.tr(preset.label)).font(.body)
+                if let sizeOverride {
+                    Text(formattedSize(sizeOverride))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text(L10n.tr(preset.description))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private func bindingFor(_ preset: IgnorePreset) -> Binding<Bool> {
+        Binding(
+            get: { isActive(preset) },
+            set: { newValue in
+                if let err = syncthingManager.togglePreset(preset, folderID: folderID, enabled: newValue) {
+                    alertMessage = err.message
+                }
+                reloadPatterns()
+            }
+        )
+    }
+
+    private func detectedToggleBinding(for item: DetectedPattern) -> Binding<Bool> {
+        Binding(
+            get: { ignoredPatterns.contains(item.pattern) },
+            set: { newValue in
+                if newValue {
+                    if let err = syncthingManager.addIgnorePattern(item.pattern, folderID: folderID) {
+                        alertMessage = err.message
+                    }
+                } else {
+                    var next = Array(ignoredPatterns)
+                    next.removeAll { $0 == item.pattern }
+                    if let err = syncthingManager.setIgnorePatterns(folderID: folderID, patterns: next) {
+                        alertMessage = err.message
+                    }
+                }
+                reloadPatterns()
+            }
+        )
+    }
+
+    // MARK: - Mutations
+
+    private func addCustom() {
+        let trimmed = newPattern.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        if let err = syncthingManager.addIgnorePattern(trimmed, folderID: folderID) {
+            alertMessage = err.message
+            return
+        }
+        newPattern = ""
+        reloadPatterns()
+    }
+
+    private func deleteCustom(at offsets: IndexSet) {
+        let visible = customPatterns
+        let toRemove = offsets.compactMap { index -> String? in
+            guard index < visible.count else { return nil }
+            return visible[index]
+        }
+        var next = Array(ignoredPatterns)
+        next.removeAll { toRemove.contains($0) }
+        if let err = syncthingManager.setIgnorePatterns(folderID: folderID, patterns: next) {
+            alertMessage = err.message
+            return
+        }
+        reloadPatterns()
+    }
+
+    // MARK: - Loading
+
+    private func initialLoad() async {
+        reloadPatterns()
+        if !hasLoadedScan {
+            hasLoadedScan = true
+            let id = folderID
+            let scanResult = await Task.detached {
+                SyncthingManager.scanFolderForKnownPatterns(folderID: id)
+            }.value
+            detected = scanResult
+        }
+    }
+
+    private func reloadPatterns() {
+        ignoredPatterns = Set(syncthingManager.ignorePatterns(folderID: folderID))
+    }
+
+    // MARK: - Formatting
+
+    private func formattedSize(_ item: DetectedPattern) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB, .useKB]
+        formatter.countStyle = .file
+        let size = formatter.string(fromByteCount: item.sizeBytes)
+        return L10n.fmt("%@ — %d files", size, item.fileCount)
+    }
+}

--- a/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
+++ b/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+struct SyncFilterRecommendationSheet: View {
+    let folderID: String
+    let folderLabel: String
+    let syncthingManager: SyncthingManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var detected: [DetectedPattern] = []
+    @State private var enabledPresetIDs: Set<String> = Set(IgnorePreset.recommended.map(\.id))
+    @State private var enabledDetectedPatterns: Set<String> = []
+    @State private var hasScanned = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text(L10n.tr("Skip these on this iPhone? You can change this anytime in Sync Filters."))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section(header: Text(L10n.tr("Recommended"))) {
+                    ForEach(IgnorePreset.recommended) { preset in
+                        presetToggle(preset)
+                    }
+                }
+
+                if !detected.isEmpty {
+                    Section(header: Text(L10n.tr("Found in this vault"))) {
+                        ForEach(detected) { item in
+                            detectedToggle(item)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(L10n.tr("Sync Filters"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(L10n.tr("Skip")) {
+                        syncthingManager.markRecommendationSheetShown(folderID: folderID)
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(L10n.tr("Done")) {
+                        apply()
+                        syncthingManager.markRecommendationSheetShown(folderID: folderID)
+                        dismiss()
+                    }
+                    .bold()
+                }
+            }
+            .task { await scan() }
+        }
+    }
+
+    private func presetToggle(_ preset: IgnorePreset) -> some View {
+        let isOn = Binding(
+            get: { enabledPresetIDs.contains(preset.id) },
+            set: { newValue in
+                if newValue {
+                    enabledPresetIDs.insert(preset.id)
+                } else {
+                    enabledPresetIDs.remove(preset.id)
+                }
+            }
+        )
+        return Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.tr(preset.label)).font(.body)
+                Text(L10n.tr(preset.description)).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func detectedToggle(_ item: DetectedPattern) -> some View {
+        let preset = IgnorePreset.preset(forDetectedPattern: item.pattern)
+        let isOn = Binding(
+            get: {
+                if let preset { return enabledPresetIDs.contains(preset.id) }
+                return enabledDetectedPatterns.contains(item.pattern)
+            },
+            set: { newValue in
+                if let preset {
+                    if newValue {
+                        enabledPresetIDs.insert(preset.id)
+                    } else {
+                        enabledPresetIDs.remove(preset.id)
+                    }
+                } else {
+                    if newValue {
+                        enabledDetectedPatterns.insert(item.pattern)
+                    } else {
+                        enabledDetectedPatterns.remove(item.pattern)
+                    }
+                }
+            }
+        )
+        return Toggle(isOn: isOn) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(L10n.tr(item.label)).font(.body)
+                Text(formattedSize(item)).font(.caption).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private func scan() async {
+        guard !hasScanned else { return }
+        hasScanned = true
+        let id = folderID
+        let result = await Task.detached {
+            SyncthingManager.scanFolderForKnownPatterns(folderID: id)
+        }.value
+        detected = result
+        for item in result {
+            if let preset = IgnorePreset.preset(forDetectedPattern: item.pattern) {
+                enabledPresetIDs.insert(preset.id)
+            } else {
+                enabledDetectedPatterns.insert(item.pattern)
+            }
+        }
+    }
+
+    private func apply() {
+        var patterns = syncthingManager.ignorePatterns(folderID: folderID)
+        for preset in IgnorePreset.all where enabledPresetIDs.contains(preset.id) {
+            for pattern in preset.patterns where !patterns.contains(pattern) {
+                patterns.append(pattern)
+            }
+        }
+        for pattern in enabledDetectedPatterns where !patterns.contains(pattern) {
+            patterns.append(pattern)
+        }
+        _ = syncthingManager.setIgnorePatterns(folderID: folderID, patterns: patterns)
+    }
+
+    private func formattedSize(_ item: DetectedPattern) -> String {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useMB, .useGB, .useKB]
+        formatter.countStyle = .file
+        let size = formatter.string(fromByteCount: item.sizeBytes)
+        return L10n.fmt("%@ — %d files", size, item.fileCount)
+    }
+}

--- a/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
+++ b/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
@@ -136,28 +136,16 @@ struct SyncFilterRecommendationSheet: View {
         }
     }
 
-    /// Compute the final `.stignore` content based on the user's choices, then
-    /// write it. Any pattern that the sheet manages (presets + detected items)
-    /// is removed first, then re-added only if currently enabled. This makes
-    /// deselect actually take effect — including for the recommended patterns
-    /// that addFolder() silently auto-applied just before the sheet appeared.
-    /// Custom/unmanaged patterns the user added previously are preserved.
+    /// Delegate the deselect-aware, safe-read apply to SyncthingManager so
+    /// the sheet stays presentation-only and the read-modify-write logic
+    /// lives next to the rest of the filter API.
     private func apply() -> SyncUserError? {
-        let existing = syncthingManager.ignorePatterns(folderID: folderID)
-        let managed = Set(IgnorePreset.all.flatMap(\.patterns))
-            .union(detected.map(\.pattern))
-
-        var patterns = existing.filter { !managed.contains($0) }
-
-        for preset in IgnorePreset.all where enabledPresetIDs.contains(preset.id) {
-            for pattern in preset.patterns where !patterns.contains(pattern) {
-                patterns.append(pattern)
-            }
-        }
-        for pattern in enabledDetectedPatterns where !patterns.contains(pattern) {
-            patterns.append(pattern)
-        }
-        return syncthingManager.setIgnorePatterns(folderID: folderID, patterns: patterns)
+        syncthingManager.applyRecommendedFilters(
+            folderID: folderID,
+            enabledPresetIDs: enabledPresetIDs,
+            detectedPatterns: detected.map(\.pattern),
+            enabledDetectedPatterns: enabledDetectedPatterns
+        )
     }
 
     private func formattedSize(_ item: DetectedPattern) -> String {

--- a/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
+++ b/ios/VaultSync/Views/SyncFilterRecommendationSheet.swift
@@ -10,6 +10,7 @@ struct SyncFilterRecommendationSheet: View {
     @State private var enabledPresetIDs: Set<String> = Set(IgnorePreset.recommended.map(\.id))
     @State private var enabledDetectedPatterns: Set<String> = []
     @State private var hasScanned = false
+    @State private var applyErrorMessage: String?
 
     var body: some View {
         NavigationStack {
@@ -45,7 +46,10 @@ struct SyncFilterRecommendationSheet: View {
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button(L10n.tr("Done")) {
-                        apply()
+                        if let err = apply() {
+                            applyErrorMessage = err.message
+                            return
+                        }
                         syncthingManager.markRecommendationSheetShown(folderID: folderID)
                         dismiss()
                     }
@@ -53,7 +57,16 @@ struct SyncFilterRecommendationSheet: View {
                 }
             }
             .task { await scan() }
+            .alert(L10n.tr("Could not save filters"), isPresented: errorBinding) {
+                Button(L10n.tr("OK")) { applyErrorMessage = nil }
+            } message: {
+                Text(applyErrorMessage ?? "")
+            }
         }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(get: { applyErrorMessage != nil }, set: { if !$0 { applyErrorMessage = nil } })
     }
 
     private func presetToggle(_ preset: IgnorePreset) -> some View {
@@ -123,8 +136,19 @@ struct SyncFilterRecommendationSheet: View {
         }
     }
 
-    private func apply() {
-        var patterns = syncthingManager.ignorePatterns(folderID: folderID)
+    /// Compute the final `.stignore` content based on the user's choices, then
+    /// write it. Any pattern that the sheet manages (presets + detected items)
+    /// is removed first, then re-added only if currently enabled. This makes
+    /// deselect actually take effect — including for the recommended patterns
+    /// that addFolder() silently auto-applied just before the sheet appeared.
+    /// Custom/unmanaged patterns the user added previously are preserved.
+    private func apply() -> SyncUserError? {
+        let existing = syncthingManager.ignorePatterns(folderID: folderID)
+        let managed = Set(IgnorePreset.all.flatMap(\.patterns))
+            .union(detected.map(\.pattern))
+
+        var patterns = existing.filter { !managed.contains($0) }
+
         for preset in IgnorePreset.all where enabledPresetIDs.contains(preset.id) {
             for pattern in preset.patterns where !patterns.contains(pattern) {
                 patterns.append(pattern)
@@ -133,7 +157,7 @@ struct SyncFilterRecommendationSheet: View {
         for pattern in enabledDetectedPatterns where !patterns.contains(pattern) {
             patterns.append(pattern)
         }
-        _ = syncthingManager.setIgnorePatterns(folderID: folderID, patterns: patterns)
+        return syncthingManager.setIgnorePatterns(folderID: folderID, patterns: patterns)
     }
 
     private func formattedSize(_ item: DetectedPattern) -> String {

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -459,3 +459,37 @@
 "Cloud Relay is available for faster background updates." = "Cloud Relay steht für schnellere Hintergrundaktualisierungen bereit.";
 "Cloud Relay is not enabled." = "Cloud Relay ist nicht aktiviert.";
 "Enable Cloud Relay later in Settings if you want faster background updates." = "Aktiviere Cloud Relay später in den Einstellungen, wenn du schnellere Hintergrundaktualisierungen möchtest.";
+
+/* Sync Filters */
+"Sync Filters" = "Sync-Filter";
+"Recommended" = "Empfohlen";
+"Found in this vault" = "In diesem Vault gefunden";
+"Other presets" = "Weitere Voreinstellungen";
+"Custom patterns" = "Eigene Muster";
+"How filters work" = "Wie Filter funktionieren";
+"Add pattern (e.g. *.tmp)" = "Muster hinzufügen (z. B. *.tmp)";
+"Sync Filter Error" = "Sync-Filter-Fehler";
+"Skip these on this iPhone? You can change this anytime in Sync Filters." = "Diese auf diesem iPhone überspringen? Du kannst das jederzeit in den Sync-Filtern ändern.";
+"Skip" = "Überspringen";
+"Choose what gets synced to this iPhone" = "Wähle, was auf dieses iPhone synchronisiert wird";
+"Always skip on this iPhone" = "Auf diesem iPhone immer überspringen";
+"More actions" = "Weitere Aktionen";
+"Skipping enabled" = "Überspringen aktiviert";
+"'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "„%@“ wird nicht mehr auf dieses iPhone synchronisiert. Du kannst das in den Sync-Filtern rückgängig machen.";
+"Could not add filter" = "Filter konnte nicht hinzugefügt werden";
+"%@ — %d files" = "%@ — %d Dateien";
+
+/* IgnorePreset labels and descriptions */
+"Workspace state" = "Arbeitsbereich-Zustand";
+"Prevents sync conflicts on which notes were open." = "Verhindert Sync-Konflikte über zuletzt geöffnete Notizen.";
+"Trash" = "Papierkorb";
+"Files already deleted on other devices." = "Bereits auf anderen Geräten gelöschte Dateien.";
+"Git repository" = "Git-Repository";
+"Version history — rarely useful on iPhone." = "Versionsverlauf — auf dem iPhone selten nützlich.";
+"macOS metadata" = "macOS-Metadaten";
+"Finder metadata files like .DS_Store." = "Finder-Metadatendateien wie .DS_Store.";
+"Copilot index" = "Copilot-Index";
+"Cache of Obsidian Copilot, regenerated automatically." = "Cache von Obsidian Copilot, wird automatisch neu erzeugt.";
+"Obsidian app cache" = "Obsidian-App-Cache";
+"Auto-regenerated Obsidian internal cache." = "Automatisch regenerierter interner Obsidian-Cache.";
+"Node modules" = "Node-Module";

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -477,6 +477,7 @@
 "Skipping enabled" = "Überspringen aktiviert";
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "„%@“ wird nicht mehr auf dieses iPhone synchronisiert. Du kannst das in den Sync-Filtern rückgängig machen.";
 "Could not add filter" = "Filter konnte nicht hinzugefügt werden";
+"Could not save filters" = "Filter konnten nicht gespeichert werden";
 "%@ — %d files" = "%@ — %d Dateien";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "„%@“ wird nicht mehr auf dieses iPhone synchronisiert. Du kannst das in den Sync-Filtern rückgängig machen.";
 "Could not add filter" = "Filter konnte nicht hinzugefügt werden";
 "Could not save filters" = "Filter konnten nicht gespeichert werden";
+"Could not read current sync filters. Please try again." = "Aktuelle Sync-Filter konnten nicht gelesen werden. Bitte erneut versuchen.";
 "%@ — %d files" = "%@ — %d Dateien";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -460,3 +460,37 @@
 "Cloud Relay is available for faster background updates." = "Cloud Relay is available for faster background updates.";
 "Cloud Relay is not enabled." = "Cloud Relay is not enabled.";
 "Enable Cloud Relay later in Settings if you want faster background updates." = "Enable Cloud Relay later in Settings if you want faster background updates.";
+
+/* Sync Filters */
+"Sync Filters" = "Sync Filters";
+"Recommended" = "Recommended";
+"Found in this vault" = "Found in this vault";
+"Other presets" = "Other presets";
+"Custom patterns" = "Custom patterns";
+"How filters work" = "How filters work";
+"Add pattern (e.g. *.tmp)" = "Add pattern (e.g. *.tmp)";
+"Sync Filter Error" = "Sync Filter Error";
+"Skip these on this iPhone? You can change this anytime in Sync Filters." = "Skip these on this iPhone? You can change this anytime in Sync Filters.";
+"Skip" = "Skip";
+"Choose what gets synced to this iPhone" = "Choose what gets synced to this iPhone";
+"Always skip on this iPhone" = "Always skip on this iPhone";
+"More actions" = "More actions";
+"Skipping enabled" = "Skipping enabled";
+"'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters.";
+"Could not add filter" = "Could not add filter";
+"%@ — %d files" = "%@ — %d files";
+
+/* IgnorePreset labels and descriptions */
+"Workspace state" = "Workspace state";
+"Prevents sync conflicts on which notes were open." = "Prevents sync conflicts on which notes were open.";
+"Trash" = "Trash";
+"Files already deleted on other devices." = "Files already deleted on other devices.";
+"Git repository" = "Git repository";
+"Version history — rarely useful on iPhone." = "Version history — rarely useful on iPhone.";
+"macOS metadata" = "macOS metadata";
+"Finder metadata files like .DS_Store." = "Finder metadata files like .DS_Store.";
+"Copilot index" = "Copilot index";
+"Cache of Obsidian Copilot, regenerated automatically." = "Cache of Obsidian Copilot, regenerated automatically.";
+"Obsidian app cache" = "Obsidian app cache";
+"Auto-regenerated Obsidian internal cache." = "Auto-regenerated Obsidian internal cache.";
+"Node modules" = "Node modules";

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "Skipping enabled" = "Skipping enabled";
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters.";
 "Could not add filter" = "Could not add filter";
+"Could not save filters" = "Could not save filters";
 "%@ — %d files" = "%@ — %d files";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -479,6 +479,7 @@
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters.";
 "Could not add filter" = "Could not add filter";
 "Could not save filters" = "Could not save filters";
+"Could not read current sync filters. Please try again." = "Could not read current sync filters. Please try again.";
 "%@ — %d files" = "%@ — %d files";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -459,3 +459,37 @@
 "Cloud Relay is available for faster background updates." = "Cloud Relay 可用于更快的后台更新。";
 "Cloud Relay is not enabled." = "Cloud Relay 未启用。";
 "Enable Cloud Relay later in Settings if you want faster background updates." = "如果你希望更快的后台更新，可以稍后在“设置”中启用 Cloud Relay。";
+
+/* Sync Filters */
+"Sync Filters" = "同步过滤器";
+"Recommended" = "推荐";
+"Found in this vault" = "在此 Vault 中找到";
+"Other presets" = "其他预设";
+"Custom patterns" = "自定义规则";
+"How filters work" = "过滤器工作原理";
+"Add pattern (e.g. *.tmp)" = "添加规则(例如 *.tmp)";
+"Sync Filter Error" = "同步过滤器错误";
+"Skip these on this iPhone? You can change this anytime in Sync Filters." = "在此 iPhone 上跳过这些？你可以随时在同步过滤器中修改。";
+"Skip" = "跳过";
+"Choose what gets synced to this iPhone" = "选择要同步到此 iPhone 的内容";
+"Always skip on this iPhone" = "在此 iPhone 上始终跳过";
+"More actions" = "更多操作";
+"Skipping enabled" = "跳过已启用";
+"'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "「%@」将不再同步到此 iPhone。你可以在同步过滤器中撤销。";
+"Could not add filter" = "无法添加过滤器";
+"%@ — %d files" = "%@ — %d 个文件";
+
+/* IgnorePreset labels and descriptions */
+"Workspace state" = "工作区状态";
+"Prevents sync conflicts on which notes were open." = "防止当前打开笔记的同步冲突。";
+"Trash" = "废纸篓";
+"Files already deleted on other devices." = "已在其他设备上删除的文件。";
+"Git repository" = "Git 仓库";
+"Version history — rarely useful on iPhone." = "版本历史 — 在 iPhone 上很少用到。";
+"macOS metadata" = "macOS 元数据";
+"Finder metadata files like .DS_Store." = "Finder 元数据文件，如 .DS_Store。";
+"Copilot index" = "Copilot 索引";
+"Cache of Obsidian Copilot, regenerated automatically." = "Obsidian Copilot 的缓存，会自动重建。";
+"Obsidian app cache" = "Obsidian 应用缓存";
+"Auto-regenerated Obsidian internal cache." = "自动重建的 Obsidian 内部缓存。";
+"Node modules" = "Node 模块";

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -477,6 +477,7 @@
 "Skipping enabled" = "跳过已启用";
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "「%@」将不再同步到此 iPhone。你可以在同步过滤器中撤销。";
 "Could not add filter" = "无法添加过滤器";
+"Could not save filters" = "无法保存过滤器";
 "%@ — %d files" = "%@ — %d 个文件";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -478,6 +478,7 @@
 "'%@' will no longer sync to this iPhone. You can undo this in Sync Filters." = "「%@」将不再同步到此 iPhone。你可以在同步过滤器中撤销。";
 "Could not add filter" = "无法添加过滤器";
 "Could not save filters" = "无法保存过滤器";
+"Could not read current sync filters. Please try again." = "无法读取当前同步过滤器。请重试。";
 "%@ — %d files" = "%@ — %d 个文件";
 
 /* IgnorePreset labels and descriptions */

--- a/ios/VaultSyncTests/IgnorePresetTests.swift
+++ b/ios/VaultSyncTests/IgnorePresetTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import VaultSync
+
+@Suite("IgnorePreset catalog")
+struct IgnorePresetTests {
+    @Test func recommendedContainsWorkspaceAndTrash() {
+        let ids = IgnorePreset.recommended.map(\.id)
+        #expect(ids == ["workspace", "trash"])
+    }
+
+    @Test func allPresetsHaveNonEmptyPatterns() {
+        for preset in IgnorePreset.all {
+            #expect(!preset.patterns.isEmpty, "preset \(preset.id) has no patterns")
+        }
+    }
+
+    @Test func presetIDsAreUnique() {
+        let ids = IgnorePreset.all.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test func workspacePresetCoversBothWorkspaceFiles() {
+        let patterns = Set(IgnorePreset.workspace.patterns)
+        #expect(patterns.contains(".obsidian/workspace.json"))
+        #expect(patterns.contains(".obsidian/workspace-mobile.json"))
+    }
+
+    @Test func gitPresetIsNotInRecommended() {
+        let recommendedIDs = Set(IgnorePreset.recommended.map(\.id))
+        #expect(!recommendedIDs.contains("git"))
+    }
+
+    @Test func presetForDetectedPatternMapsGit() {
+        let preset = IgnorePreset.preset(forDetectedPattern: ".git")
+        #expect(preset?.id == "git")
+    }
+
+    @Test func presetForDetectedPatternMapsCopilot() {
+        let preset = IgnorePreset.preset(forDetectedPattern: ".copilot-index")
+        #expect(preset?.id == "copilot")
+    }
+
+    @Test func presetForDetectedPatternReturnsNilForUnknown() {
+        let preset = IgnorePreset.preset(forDetectedPattern: "node_modules")
+        #expect(preset == nil)
+    }
+}

--- a/ios/VaultSyncTests/SyncFiltersTests.swift
+++ b/ios/VaultSyncTests/SyncFiltersTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import VaultSync
+
+@MainActor
+@Suite("Sync Filters — recommendation sheet flag")
+struct SyncFiltersTests {
+    private static let key = "syncthing.recommendationSheetShownFolders"
+
+    @Test("Folder is unseen by default")
+    func folderUnseenByDefault() {
+        UserDefaults.standard.removeObject(forKey: Self.key)
+        let manager = SyncthingManager()
+        #expect(manager.hasShownRecommendationSheet(folderID: "vault-a") == false)
+    }
+
+    @Test("markRecommendationSheetShown persists across instances")
+    func markPersists() {
+        UserDefaults.standard.removeObject(forKey: Self.key)
+        let manager = SyncthingManager()
+        manager.markRecommendationSheetShown(folderID: "vault-a")
+        let other = SyncthingManager()
+        #expect(other.hasShownRecommendationSheet(folderID: "vault-a"))
+    }
+
+    @Test("Each folder is tracked independently")
+    func perFolderTracking() {
+        UserDefaults.standard.removeObject(forKey: Self.key)
+        let manager = SyncthingManager()
+        manager.markRecommendationSheetShown(folderID: "vault-a")
+        #expect(manager.hasShownRecommendationSheet(folderID: "vault-a"))
+        #expect(manager.hasShownRecommendationSheet(folderID: "vault-b") == false)
+    }
+
+    @Test("markRecommendationSheetShown is idempotent")
+    func markIsIdempotent() {
+        UserDefaults.standard.removeObject(forKey: Self.key)
+        let manager = SyncthingManager()
+        manager.markRecommendationSheetShown(folderID: "vault-a")
+        manager.markRecommendationSheetShown(folderID: "vault-a")
+        let stored = UserDefaults.standard.array(forKey: Self.key) as? [String]
+        #expect(stored?.count == 1)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -50,8 +50,8 @@ targets:
     info:
       path: VaultSync/Info.plist
       properties:
-        CFBundleShortVersionString: "1.1.0"
-        CFBundleVersion: "20"
+        CFBundleShortVersionString: "1.2.0"
+        CFBundleVersion: "21"
         UILaunchScreen: {}
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -100,8 +100,8 @@ targets:
     info:
       path: VaultSyncWidget/Info.plist
       properties:
-        CFBundleShortVersionString: "1.1.0"
-        CFBundleVersion: "20"
+        CFBundleShortVersionString: "1.2.0"
+        CFBundleVersion: "21"
         CFBundleDisplayName: VaultSync Widget
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension


### PR DESCRIPTION
Closes #1.

Adds a per-vault Sync Filters UI on top of the existing `GetFolderIgnores` / `SetFolderIgnores` bridge functions. Users can toggle preset ignore-pattern groups in plain language, edit custom patterns, see a vault scan that surfaces actual byte sizes of heavy folders, and skip conflicting files in one tap from the conflict resolver.

## What's in

**Bridge**

- `ScanFolderForKnownPatterns` (Go) — checks the sync folder root and one level deep into each non-hidden subdirectory, aggregates matches per pattern (designed for "Obsidian root + multiple vaults as subdirs" layouts). Detects `.git`, `.copilot-index`, `node_modules`, `.obsidian/cache`. 7 unit tests including nested-vault and hidden-subdir cases.

**Models & service**

- `IgnorePreset` catalog: Workspace state, Trash, Git repository, macOS metadata, Copilot index, Obsidian app cache. Recommended set (Workspace + Trash) is silently applied to new folders.
- `SyncthingManager` filter API: `ignorePatterns`, `setIgnorePatterns`, `togglePreset`, `addIgnorePattern`, `scanFolderForKnownPatterns`, plus per-folder UserDefaults flag for the first-run sheet.
- Existing 3 silent default patterns migrate automatically: derived state shows Workspace + Trash as ON; nothing on disk changes.

**UI**

- `IgnorePatternsView` (Recommended / Found in this vault / Other presets / Custom patterns / footer link to Syncthing pattern docs).
- `SyncFilterRecommendationSheet` shown once per vault on first detail-view open; pre-checks Recommended + auto-checks anything heavy the scan found.
- `ContentView`: `NavigationLink` between Conflicts and Shared With sections.
- `ConflictDiffView`: top-bar menu with **Always skip on this iPhone** (adds the conflict's exact relative path to the folder's ignore list).

**Localization**

en, de, zh-Hans for all new strings.

## Pattern semantics — verified

Confirmed via `lib/ignore/ignore.go:474-488`: Syncthing auto-expands every unanchored pattern to also match at any depth. So `.git`, `.obsidian/workspace.json`, `.Trash` etc. correctly match in deeply nested vault subdirectories without needing a `**/` prefix.

## Spec

Full UX spec lives in `docs/sync-filters-ux.md` (mockups, preset catalog, migration plan, multi-vault behavior).

## Tests

- Go: full bridge regression (~40s) including 7 new scanner tests
- Swift: 12 new unit tests (IgnorePreset catalog + recommendation-sheet flag)
- Manual smoke test on physical iPhone with multi-vault Obsidian setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Sync Filters UI for per-vault ignore patterns

Adds a user-facing "Sync Filters" UI to manage `.stignore` patterns per vault, allowing users to exclude heavy or irrelevant folders (`.git`, `node_modules`, `.obsidian/cache`, etc.) from syncing without manually editing configuration files.

## User-visible features

- **Sync Filters screen**: New "Sync Filters" link in vault detail view. Displays five sections: Recommended presets (Workspace state, Trash), detected patterns found by folder scanning with sizes/file counts, other available presets (Git, macOS metadata, Copilot index, Obsidian cache), custom pattern editor (add/delete), and link to Syncthing docs.

- **First-run recommendation sheet**: Shown once per vault (tracked via UserDefaults). Auto-detects heavy folders and pre-checks recommended presets; users can toggle selections and apply or skip.

- **Conflict resolution action**: New "Always skip on this iPhone" toolbar action in `ConflictDiffView` that adds a conflict path to the folder's ignore list with undoable confirmation.

- **Smart defaults**: New vaults silently apply Workspace + Trash presets by default. Existing vaults preserve their current `.stignore` without overwriting on app update.

- **Localization**: All new UI strings translated to English, German, and Simplified Chinese.

## Technical implementation

- **Go bridge**: New `ScanFolderForKnownPatterns()` function scans vault root and one directory level deep (skipping hidden dirs), totals file sizes and counts, and returns detected patterns as JSON.

- **Pattern semantics**: Uses Syncthing-compatible patterns that auto-expand unanchored patterns to match at any depth, ensuring consistency with Syncthing's native behavior.

- **Safe read-modify-write**: `.stignore` reads are guarded against malformed files; writes abort with `SyncUserError` on decode failure to prevent silent overwrites.

- **Preset management**: `IgnorePreset` catalog maps preset IDs to pattern groups; toggle operations preserve user-added custom patterns and handle deselection-aware merges.

## Testing

- **Go**: 7 new scanner unit tests covering `.git` detection, empty vaults, multiple candidates, nested vaults, hidden directories, and empty directories. Full bridge regression suite (~40s).
- **Swift**: 12 new unit tests for preset catalog integrity, recommendation-sheet state tracking, and per-folder persistence.
- **Manual**: Multi-vault smoke test performed.

## Privacy/security & background execution

No background execution changes. Folder scanning happens only on-demand when the Sync Filters sheet is presented. No privacy impact; scanning is local to the vault and detection results are stored only in memory or UserDefaults for the "shown" flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->