### PR TITLE
docs: fix ASCII diagram alignment in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ VoiceOver and Dynamic Type support are included throughout the app.
 
 ```text
 ┌──────────────┐     Syncthing protocol      ┌──────────────────┐
-│  Your Mac /  │◄───────────────────────────►│    VaultSync      │
-│  Linux / NAS │     LAN or Internet          │    iOS / iPadOS   │
-│  + Syncthing │                              │                  │
-└──────┬───────┘                              │  Syncs directly   │
-       │                                      │  into Obsidian’s  │
-       │                                      │  iOS sandbox      │
-       │                                      └────────▲─────────┘
+│  Your Mac /  │◄───────────────────────────►│    VaultSync     │
+│  Linux / NAS │     LAN or Internet         │    iOS / iPadOS  │
+│  + Syncthing │                             │                  │
+└──────┬───────┘                             │  Syncs directly  │
+       │                                     │  into Obsidian’s │
+       │                                     │  iOS sandbox     │
+       │                                     └────────▲─────────┘
        │                                               │
        │  Optional                                     │
        │  vaultsync-notify                             │


### PR DESCRIPTION
Cosmetic fix: trailing spaces inside the architecture diagram boxes now line up the right border. No functional change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation

Fixed spacing and alignment in the "How it works" ASCII diagram in `README.md`. Trailing spaces within the architecture diagram boxes now properly align the right borders, improving visual consistency of the diagram.

This is a purely cosmetic change with no impact on functionality or behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psimaker/vaultsync/pull/3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->