### PR TITLE
feat: improve sync responsiveness (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to VaultSync are documented here.
 
 ---
 
+## [1.3.0] — 2026-05-11
+
+### Added
+
+- **Pull-to-refresh on the main screen** — Swipe down on the vault list to trigger an immediate sync, the same gesture you use in Mail or Files. Useful when you've just edited a note in Obsidian and want it on your desktop right away.
+- **Automatic rescan when returning to VaultSync** — If you've been away from the app for more than five seconds, opening it again triggers a fresh scan of your vaults. The "close VaultSync and reopen it" workaround is no longer needed to see recent edits sync through.
+
+### Changed
+
+- **Faster fallback rescan interval** — The safety-net rescan that catches changes the iOS file-system watcher misses (for example edits made in Obsidian's sandbox while VaultSync is in the background) now runs every minute instead of every hour. Existing vaults are migrated on first launch; vaults with a user-customised interval keep their value.
+
+---
+
 ## [1.2.0] — 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,15 +99,13 @@ VaultSync is also not a magic always-on Syncthing daemon for iOS. Apple’s back
 
 ---
 
-## What’s New — v1.2.0
+## What’s New — v1.3.0
 
-> **Sync Filters** — A new per-vault screen lets you toggle preset ignore-pattern groups in plain language: Workspace state, Trash, Git repository, macOS metadata, Copilot index, and Obsidian app cache. No `.stignore` syntax needed.
+> **Pull-to-refresh on the vault list** — Swipe down to force an immediate sync, the same gesture you already use in Mail and Files.
 >
-> **Vault scan with size figures** — VaultSync scans your folder for heavy directories (`.git`, `.copilot-index`, `node_modules`, `.obsidian/cache`) and shows actual size in MB so you can decide what to skip.
+> **Auto-rescan when reopening the app** — Come back after editing in Obsidian and VaultSync scans your vaults straight away. No more "close and reopen" workaround.
 >
-> **Always skip on this iPhone** — A one-tap menu item in the conflict resolver permanently excludes the conflicting file from this device.
->
-> **First-run recommendation sheet** — A friendly intro the first time you open a new vault, with sensible defaults pre-checked.
+> **Faster recovery from missed file-change events** — The fallback rescan interval is now one minute instead of one hour, so even when iOS sandboxing prevents real-time notifications, your edits propagate quickly.
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
 

--- a/go/bridge/folders.go
+++ b/go/bridge/folders.go
@@ -10,6 +10,12 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
+// defaultRescanIntervalS is the safety-net rescan interval applied to folders
+// created by VaultSync. Matches Syncthing's own default — short enough to
+// recover quickly when the FSWatcher misses an event (e.g. cross-sandbox
+// writes from Obsidian via a security-scoped bookmark on iOS).
+const defaultRescanIntervalS = 60
+
 // FolderInfo is the JSON-serializable representation of a configured folder.
 type FolderInfo struct {
 	ID        string   `json:"id"`
@@ -51,7 +57,7 @@ func AddFolder(id, label, path string) string {
 		Label:            label,
 		Path:             path,
 		Type:             config.FolderTypeSendReceive,
-		RescanIntervalS:  3600,
+		RescanIntervalS:  defaultRescanIntervalS,
 		FSWatcherEnabled: true,
 		FSWatcherDelayS:  10,
 		AutoNormalize:    true,

--- a/go/bridge/pendingfolders.go
+++ b/go/bridge/pendingfolders.go
@@ -140,7 +140,7 @@ func AcceptPendingFolder(folderID, label, path string) string {
 		Label:            label,
 		Path:             path,
 		Type:             config.FolderTypeSendReceive,
-		RescanIntervalS:  3600,
+		RescanIntervalS:  defaultRescanIntervalS,
 		FSWatcherEnabled: true,
 		FSWatcherDelayS:  10,
 		AutoNormalize:    true,

--- a/go/bridge/rescan_migration_test.go
+++ b/go/bridge/rescan_migration_test.go
@@ -1,0 +1,116 @@
+package bridge
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/config"
+)
+
+func TestAddFolder_DefaultsTo60sRescan(t *testing.T) {
+	configDir := testConfigDir(t)
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	folderPath := filepath.Join(configDir, "rescan-default")
+	if errMsg := AddFolder("rescan-default", "Rescan Default", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+
+	folder, exists := stCfg.Folders()["rescan-default"]
+	if !exists {
+		t.Fatalf("folder not found in config after AddFolder")
+	}
+	if folder.RescanIntervalS != 60 {
+		t.Errorf("RescanIntervalS = %d, want 60 (Syncthing's standard default)", folder.RescanIntervalS)
+	}
+}
+
+func TestStart_MigratesLegacy3600(t *testing.T) {
+	configDir := testConfigDir(t)
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("first StartSyncthing() failed: %s", errMsg)
+	}
+
+	folderPath := filepath.Join(configDir, "legacy-folder")
+	if errMsg := AddFolder("legacy", "Legacy", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+
+	// Simulate a pre-migration on-disk state: an existing folder still carrying
+	// the old VaultSync default of 3600 seconds.
+	waiter, err := stCfg.Modify(func(cfg *config.Configuration) {
+		for i := range cfg.Folders {
+			if cfg.Folders[i].ID == "legacy" {
+				cfg.Folders[i].RescanIntervalS = 3600
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("setup Modify failed: %v", err)
+	}
+	waiter.Wait()
+
+	StopSyncthing()
+	time.Sleep(100 * time.Millisecond) // allow async config flush
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("second StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	folder, exists := stCfg.Folders()["legacy"]
+	if !exists {
+		t.Fatalf("folder not found after restart")
+	}
+	if folder.RescanIntervalS != 60 {
+		t.Errorf("RescanIntervalS = %d after migration, want 60", folder.RescanIntervalS)
+	}
+}
+
+func TestStart_PreservesCustomInterval(t *testing.T) {
+	configDir := testConfigDir(t)
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("first StartSyncthing() failed: %s", errMsg)
+	}
+
+	folderPath := filepath.Join(configDir, "custom-folder")
+	if errMsg := AddFolder("custom", "Custom", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+
+	// User-customised interval — neither the legacy 3600 nor the new default 60.
+	waiter, err := stCfg.Modify(func(cfg *config.Configuration) {
+		for i := range cfg.Folders {
+			if cfg.Folders[i].ID == "custom" {
+				cfg.Folders[i].RescanIntervalS = 120
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("setup Modify failed: %v", err)
+	}
+	waiter.Wait()
+
+	StopSyncthing()
+	time.Sleep(100 * time.Millisecond)
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("second StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	folder, exists := stCfg.Folders()["custom"]
+	if !exists {
+		t.Fatalf("folder not found after restart")
+	}
+	if folder.RescanIntervalS != 120 {
+		t.Errorf("RescanIntervalS = %d after migration, want 120 (user-customised value must be preserved)", folder.RescanIntervalS)
+	}
+}

--- a/go/bridge/syncthing.go
+++ b/go/bridge/syncthing.go
@@ -116,6 +116,23 @@ func StartSyncthing(configDir string) string {
 	}
 	waiter.Wait()
 
+	// Migration: lower the over-conservative 60-minute rescan fallback that
+	// older VaultSync builds wrote to disk down to Syncthing's standard 60 s.
+	// Only touches folders that still carry the legacy default — user-customised
+	// values are preserved.
+	waiter, err = stCfg.Modify(func(cfg *config.Configuration) {
+		for i := range cfg.Folders {
+			if cfg.Folders[i].RescanIntervalS == 3600 {
+				cfg.Folders[i].RescanIntervalS = defaultRescanIntervalS
+			}
+		}
+	})
+	if err != nil {
+		cancel()
+		return fmt.Sprintf("migrate rescan interval: %v", err)
+	}
+	waiter.Wait()
+
 	// Open database.
 	sdb, err := syncthing.OpenDatabase(
 		locations.Get(locations.Database),

--- a/ios/VaultSync/App/VaultSyncApp.swift
+++ b/ios/VaultSync/App/VaultSyncApp.swift
@@ -10,7 +10,10 @@ struct VaultSyncApp: App {
     @State private var syncthingManager = SyncthingManager()
     @State private var vaultManager = VaultManager()
     @State private var subscriptionManager = SubscriptionManager()
+    @State private var lastBackgroundedAt: Date?
     @Environment(\.scenePhase) private var scenePhase
+
+    private static let foregroundRescanThreshold: TimeInterval = 5
 
     init() {
         BackgroundSyncService.registerTasks()
@@ -57,8 +60,22 @@ struct VaultSyncApp: App {
                     }
                     vaultManager.restoreAccess()
                     syncthingManager.start()
+                } else if BackgroundSyncService.shouldRescanOnForeground(
+                    now: Date(),
+                    lastBackgroundedAt: lastBackgroundedAt,
+                    threshold: Self.foregroundRescanThreshold
+                ) {
+                    // Bridge is still alive but the app spent enough time in
+                    // the background that the user likely edited the vault
+                    // from another app (e.g. Obsidian). The iOS FSWatcher
+                    // doesn't reliably see cross-sandbox writes, so trigger
+                    // a fresh scan to pick them up immediately.
+                    syncthingManager.triggerForegroundSync()
                 }
+                lastBackgroundedAt = nil
             case .background:
+                lastBackgroundedAt = Date()
+
                 // Release the foreground lifecycle lock so silent-push and
                 // BGAppRefresh handlers can manage Syncthing when the process
                 // is later resumed — without this, backgroundManaged stays

--- a/ios/VaultSync/Services/BackgroundSyncService.swift
+++ b/ios/VaultSync/Services/BackgroundSyncService.swift
@@ -101,6 +101,19 @@ enum BackgroundSyncService {
         logger.info("Foreground lifecycle lock released")
     }
 
+    /// Pure predicate: should the app trigger a foreground rescan when the
+    /// scene returns to `.active`? True when the previous-background duration
+    /// reaches `threshold`. Debounces brief Control-Center swipes that would
+    /// otherwise spam rescans on every minor scene flip.
+    static func shouldRescanOnForeground(
+        now: Date,
+        lastBackgroundedAt: Date?,
+        threshold: TimeInterval
+    ) -> Bool {
+        guard let lastBackgroundedAt else { return false }
+        return now.timeIntervalSince(lastBackgroundedAt) >= threshold
+    }
+
     /// Begin a UIApplication background-task assertion so iOS grants up to
     /// ~30 seconds of continued execution after the app is backgrounded.
     /// Without this the system can suspend the process within ~5s, severing

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -554,6 +554,17 @@ final class SyncthingManager {
         }
     }
 
+    /// Async variant of `triggerForegroundSync` for callers that want to await
+    /// completion — e.g. SwiftUI `.refreshable`, where the spinner should stay
+    /// visible until the trigger has actually landed in the bridge.
+    func performForegroundSync(folderID: String? = nil) async {
+        guard !isAnySyncing else {
+            logger.info("Ignoring sync request because a sync is already in progress")
+            return
+        }
+        await performForegroundSyncRequest(folderID: folderID)
+    }
+
     // MARK: - Conflict management
 
     /// Resolve a conflict file. Returns nil on success.

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -28,6 +28,9 @@ struct ContentView: View {
                 vaultsSection
                 devicesSection
             }
+            .refreshable {
+                await syncthingManager.performForegroundSync()
+            }
             .navigationTitle("VaultSync")
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {

--- a/ios/VaultSyncTests/ForegroundRescanDebounceTests.swift
+++ b/ios/VaultSyncTests/ForegroundRescanDebounceTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import VaultSync
+
+@Suite("Foreground rescan debounce")
+struct ForegroundRescanDebounceTests {
+    @Test("Skips when the app was never backgrounded in this session")
+    func skipsWhenLastBackgroundedAtIsNil() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        #expect(
+            BackgroundSyncService.shouldRescanOnForeground(
+                now: now,
+                lastBackgroundedAt: nil,
+                threshold: 5
+            ) == false
+        )
+    }
+
+    @Test("Fires when backgrounded longer than the threshold")
+    func firesAboveThreshold() {
+        let now = Date(timeIntervalSince1970: 1_010)
+        let backgroundedAt = Date(timeIntervalSince1970: 1_000)
+        #expect(
+            BackgroundSyncService.shouldRescanOnForeground(
+                now: now,
+                lastBackgroundedAt: backgroundedAt,
+                threshold: 5
+            ) == true
+        )
+    }
+
+    @Test("Skips when backgrounded shorter than the threshold")
+    func skipsBelowThreshold() {
+        let now = Date(timeIntervalSince1970: 1_002)
+        let backgroundedAt = Date(timeIntervalSince1970: 1_000)
+        #expect(
+            BackgroundSyncService.shouldRescanOnForeground(
+                now: now,
+                lastBackgroundedAt: backgroundedAt,
+                threshold: 5
+            ) == false
+        )
+    }
+
+    @Test("Fires exactly at the threshold boundary")
+    func firesAtThresholdBoundary() {
+        let now = Date(timeIntervalSince1970: 1_005)
+        let backgroundedAt = Date(timeIntervalSince1970: 1_000)
+        #expect(
+            BackgroundSyncService.shouldRescanOnForeground(
+                now: now,
+                lastBackgroundedAt: backgroundedAt,
+                threshold: 5
+            ) == true
+        )
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -50,8 +50,8 @@ targets:
     info:
       path: VaultSync/Info.plist
       properties:
-        CFBundleShortVersionString: "1.2.0"
-        CFBundleVersion: "21"
+        CFBundleShortVersionString: "1.3.0"
+        CFBundleVersion: "22"
         UILaunchScreen: {}
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -100,8 +100,8 @@ targets:
     info:
       path: VaultSyncWidget/Info.plist
       properties:
-        CFBundleShortVersionString: "1.2.0"
-        CFBundleVersion: "21"
+        CFBundleShortVersionString: "1.3.0"
+        CFBundleVersion: "22"
         CFBundleDisplayName: VaultSync Widget
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension


### PR DESCRIPTION
Closes #4.

## Summary

- Lower the per-folder `RescanIntervalS` from 3600 s to 60 s (Syncthing's own default). Existing folders carrying the legacy 3600 are migrated on bridge start; user-customised values are preserved.
- Auto-trigger a foreground rescan when the scene returns to `.active` after the app was backgrounded for ≥5 s, so edits made in Obsidian on iOS show up without the close-and-reopen workaround.
- Add pull-to-refresh on the main vault list as a deliberate, low-noise manual sync hook (no dedicated button on the home screen).

Addresses the issue surfaced on Reddit by u/wet_tank. Cloud Relay does not cover the iPhone → desktop direction (notify lives on the desktop), so the fix lives entirely on the iOS / bridge side.

## Test plan

- [x] Go bridge unit tests (`rescan_migration_test.go`): default = 60, legacy 3600 → migrated to 60, custom 120 preserved.
- [x] Swift unit tests (`ForegroundRescanDebounceTests`): predicate fires above threshold, skips below, handles nil, fires at exact boundary.
- [x] Full Go bridge suite green.
- [x] Full iOS test suite (36 tests) green.
- [ ] Manual: pull-to-refresh gesture on main vault list triggers a sync.
- [ ] Manual: background app >5 s → return → auto-rescan fires. Background <5 s → return → no rescan.
- [ ] Manual: existing on-device install with at least one vault → after this build, that vault's `RescanIntervalS` is 60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves iPhone → desktop sync responsiveness by reducing fallback rescan latency, adding a foreground rescan when the app returns from background, and exposing a manual pull-to-refresh.

User-visible sync behavior
- New folders now use a 60 s rescan interval (Syncthing default) instead of 3600 s.
- Existing folders with the legacy 3600 s value are migrated to 60 s at bridge startup; any user-customized rescan intervals are preserved.
- When the app returns to .active after being backgrounded for ≥5 s, the app triggers an immediate foreground rescan so edits made in Obsidian on iOS surface on desktop without restarting VaultSync.
- Main vault list gains pull-to-refresh as a manual sync trigger.

Implementation highlights
- Go bridge: introduced defaultRescanIntervalS = 60, updated AddFolder and AcceptPendingFolder to use it, and added a startup migration in StartSyncthing that replaces legacy 3600 s values with 60 s while preserving custom values.
- iOS app: track lastBackgroundedAt in VaultSyncApp; added BackgroundSyncService.shouldRescanOnForeground(now:lastBackgroundedAt:threshold:), an async SyncthingManager.performForegroundSync(folderID:) wrapper, and a .refreshable pull-to-refresh on the main vault list.
- Documentation: bump to v1.3.0 and list these changes in README/CHANGELOG.

Privacy / security impact
- No new network endpoints or background upload behavior introduced. The changes only alter rescan timing and foreground-triggered syncs; user data handling and Syncthing security model are unchanged.

Background execution impact
- Foreground rescan is triggered only when returning to .active after a threshold and is gated by existing bridge-running/sync-in-progress checks. Existing background assertion and continued-processing behavior remain unchanged.

Test coverage and outstanding verification
- Added Go tests (3) covering default rescan assignment, legacy-3600→60 migration, and preservation of custom intervals.
- Added Swift tests (4) for the foreground-rescan debounce predicate (nil, below/above/equal-threshold cases).
- CI: unit test suites for Go and Swift are green.
- Manual verification still pending for: pull-to-refresh UX, background-duration-triggered rescan in real-world usage, and migration behavior on existing user installs.

Closes #4.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psimaker/vaultsync/pull/5)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->