### PR TITLE
Fix/UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to VaultSync are documented here.
 
 ---
 
+## [1.3.1] — 2026-05-17
+
+### Fixed
+
+- **Conflict button no longer also opens the browser** ([#6](https://github.com/psimaker/vaultsync/issues/6)) — Tapping "Resolve Conflicts" in the home-screen Sync Issues section pushed the conflict list **and** opened Safari at the same time, because the "Learn how to fix" link shared a list row with the navigation control. The link is now a dedicated button that consumes the tap, so the two gestures no longer collide. The same pattern was rolled out to every "Learn how to fix" spot in the app.
+- **Missing German and Simplified Chinese translations for Sync Issue titles** — Strings like "1 Conflict Needs Resolution" appeared in English on non-English locales because the keys were absent from `Localizable.strings`. Added the missing entries for all four issue kinds (folder errors, disconnected devices, pending shares, conflicts).
+
+### Changed
+
+- **Home screen reads as content, not chrome** — The large "VaultSync" navigation title is gone; the bar stays inline so the dashboard and vault list lead the eye.
+- **Device list shows just the name** — The long Syncthing Device ID no longer appears under each peer on the home screen. Tap a device to see the full ID in the detail view.
+- **Cloud Relay settings declutter** — Per-device provisioning rows are now hidden when the device is already provisioned, so only devices that need attention surface. The "Retry Provisioning" button has been removed from Settings; the same action stays available in Relay Diagnostics where the other advanced controls live.
+- **Settings → This Device tightened** — The standalone Device ID display has been removed. The "Copy Device ID" button is sufficient on its own.
+
+---
+
 ## [1.3.0] — 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -99,13 +99,13 @@ VaultSync is also not a magic always-on Syncthing daemon for iOS. Apple’s back
 
 ---
 
-## What’s New — v1.3.0
+## What’s New — v1.3.1
 
-> **Pull-to-refresh on the vault list** — Swipe down to force an immediate sync, the same gesture you already use in Mail and Files.
+> **Conflict button no longer also opens the browser** — Tapping "Resolve Conflicts" on the home screen now just opens the conflict list, instead of also launching Safari at the same time.
 >
-> **Auto-rescan when reopening the app** — Come back after editing in Obsidian and VaultSync scans your vaults straight away. No more "close and reopen" workaround.
+> **Cleaner home screen and settings** — The "VaultSync" page title is gone, devices show just their name, and Settings no longer surfaces per-device rows for relay peers that are already provisioned.
 >
-> **Faster recovery from missed file-change events** — The fallback rescan interval is now one minute instead of one hour, so even when iOS sandboxing prevents real-time notifications, your edits propagate quickly.
+> **German and Simplified Chinese fixes** — The Sync Issues titles ("1 Konflikt muss gelöst werden", "1 个冲突待解决", …) are now translated instead of falling back to English.
 
 See [CHANGELOG.md](CHANGELOG.md) for full details.
 

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -31,7 +31,8 @@ struct ContentView: View {
             .refreshable {
                 await syncthingManager.performForegroundSync()
             }
-            .navigationTitle("VaultSync")
+            .navigationTitle("")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button {
@@ -729,15 +730,8 @@ struct ContentView: View {
                         )
                     } label: {
                         HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(device.name.isEmpty ? L10n.tr("Unnamed") : device.name)
-                                    .font(.body)
-                                Text(device.deviceID)
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            }
+                            Text(device.name.isEmpty ? L10n.tr("Unnamed") : device.name)
+                                .font(.body)
                             Spacer()
                             HStack(spacing: 4) {
                                 Image(systemName: device.connected ? "checkmark.circle.fill" : "xmark.circle.fill")

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -213,7 +213,7 @@ struct ContentView: View {
                 }
                 .accessibilityElement(children: .combine)
                 if let url = troubleshootingURL(for: error) {
-                    Link("Learn how to fix", destination: url)
+                    ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                         .font(.caption2)
                 }
             }
@@ -239,7 +239,7 @@ struct ContentView: View {
                             }
                             if let folderError,
                                let url = troubleshootingURL(for: folderError) {
-                                Link("Learn how to fix", destination: url)
+                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                     .font(.caption2)
                             }
                         }
@@ -314,7 +314,7 @@ struct ContentView: View {
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                         if let url = SyncUserError.troubleshootingURL(anchor: vaultManager.needsReconnect ? "bookmark-access-expired" : "obsidian-folder-not-found") {
-                            Link("Learn how to fix", destination: url)
+                            ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                 .font(.caption2)
                         }
                     } else {
@@ -574,7 +574,7 @@ struct ContentView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                             if let url = troubleshootingURL(for: folderError) {
-                                Link("Learn how to fix", destination: url)
+                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                     .font(.caption2)
                             }
                         }

--- a/ios/VaultSync/Views/ExternalLinkButton.swift
+++ b/ios/VaultSync/Views/ExternalLinkButton.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Static URLs used in multiple UI surfaces. Centralizing them removes
+/// force-unwrapped string literals from view code.
+enum DocURL {
+    static let privacyPolicy = URL(string: "https://github.com/psimaker/vaultsync/blob/main/PRIVACY.md")!
+    static let termsOfUse = URL(string: "https://github.com/psimaker/vaultsync/blob/main/TERMS.md")!
+    static let syncthingIgnoring = URL(string: "https://docs.syncthing.net/users/ignoring.html")!
+}
+
+/// A link-styled button that opens a URL externally without inheriting the
+/// row-wide tap behavior of a sibling `NavigationLink`. Use instead of `Link`
+/// inside `List`/`Form` rows that also contain navigation or action controls.
+struct ExternalLinkButton: View {
+    let titleKey: LocalizedStringKey
+    let url: URL
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Button {
+            openURL(url)
+        } label: {
+            HStack(spacing: 3) {
+                Text(titleKey)
+                Image(systemName: "arrow.up.right")
+                    .imageScale(.small)
+                    .accessibilityHidden(true)
+            }
+            .contentShape(Rectangle())
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.borderless)
+    }
+}

--- a/ios/VaultSync/Views/IgnorePatternsView.swift
+++ b/ios/VaultSync/Views/IgnorePatternsView.swift
@@ -95,8 +95,7 @@ struct IgnorePatternsView: View {
 
     private var footerSection: some View {
         Section {
-            Link(L10n.tr("How filters work"),
-                 destination: URL(string: "https://docs.syncthing.net/users/ignoring.html")!)
+            ExternalLinkButton(titleKey: "How filters work", url: DocURL.syncthingIgnoring)
         }
     }
 

--- a/ios/VaultSync/Views/RelayDiagnosticsView.swift
+++ b/ios/VaultSync/Views/RelayDiagnosticsView.swift
@@ -63,7 +63,7 @@ struct RelayDiagnosticsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     if let url = SyncUserError.troubleshootingURL(anchor: "relay-unreachable") {
-                        Link("Learn how to fix", destination: url)
+                        ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                             .font(.caption2)
                     }
                 }
@@ -86,7 +86,7 @@ struct RelayDiagnosticsView: View {
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                     if let url = troubleshootingURL(for: relayError.message) {
-                        Link("Learn how to fix", destination: url)
+                        ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                             .font(.caption2)
                     }
                 }
@@ -141,7 +141,7 @@ struct RelayDiagnosticsView: View {
                         .font(.caption)
                         .foregroundStyle(.red)
                     if let url = SyncUserError.troubleshootingURL(anchor: "apns-not-registered") {
-                        Link("Learn how to fix", destination: url)
+                        ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                             .font(.caption2)
                     }
                 }
@@ -191,7 +191,7 @@ struct RelayDiagnosticsView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                             if let url = troubleshootingURL(for: reason) {
-                                Link("Learn how to fix", destination: url)
+                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                     .font(.caption2)
                             }
                         }
@@ -276,7 +276,7 @@ struct RelayDiagnosticsView: View {
                         .font(.caption)
                 }
                 if let url = SyncUserError.troubleshootingURL(anchor: "relay-unreachable") {
-                    Link("Open full relay troubleshooting", destination: url)
+                    ExternalLinkButton(titleKey: "Open full relay troubleshooting", url: url)
                         .font(.caption2)
                 }
             }

--- a/ios/VaultSync/Views/SettingsView.swift
+++ b/ios/VaultSync/Views/SettingsView.swift
@@ -10,7 +10,6 @@ struct SettingsView: View {
     @State private var alertMessage: String?
     @State private var showAlert = false
     @State private var showSetupStatus = false
-    @State private var retryProvisioningInProgress = false
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -23,14 +22,6 @@ struct SettingsView: View {
                     if syncthingManager.deviceID.isEmpty {
                         LabeledContent("Device ID", value: "Not available")
                     } else {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Device ID")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(syncthingManager.deviceID)
-                                .font(.system(.caption, design: .monospaced))
-                                .textSelection(.enabled)
-                        }
                         Button {
                             UIPasteboard.general.string = syncthingManager.deviceID
                         } label: {
@@ -126,34 +117,36 @@ struct SettingsView: View {
             if !syncthingManager.devices.isEmpty {
                 ForEach(syncthingManager.devices) { device in
                     let status = relayProvisionStatus(for: device.deviceID)
-                    VStack(alignment: .leading, spacing: 4) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(device.name.isEmpty ? device.deviceID : device.name)
-                                    .font(.subheadline)
-                                Text(device.deviceID)
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                                    .foregroundStyle(.secondary)
+                    if status != .provisioned {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(device.name.isEmpty ? device.deviceID : device.name)
+                                        .font(.subheadline)
+                                    Text(device.deviceID)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .lineLimit(1)
+                                        .truncationMode(.middle)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(status.summary)
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(relayProvisionColor(status))
                             }
-                            Spacer()
-                            Text(status.summary)
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(relayProvisionColor(status))
-                        }
-                        .accessibilityElement(children: .combine)
-                        if let reason = status.failureReason {
-                            Text(reason)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                            if let url = SyncUserError.troubleshootingURL(forRawError: reason) {
-                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
+                            .accessibilityElement(children: .combine)
+                            if let reason = status.failureReason {
+                                Text(reason)
                                     .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                if let url = SyncUserError.troubleshootingURL(forRawError: reason) {
+                                    ExternalLinkButton(titleKey: "Learn how to fix", url: url)
+                                        .font(.caption2)
+                                }
                             }
                         }
+                        .padding(.vertical, 2)
                     }
-                    .padding(.vertical, 2)
                 }
             }
 
@@ -165,26 +158,6 @@ struct SettingsView: View {
                         try? await AppStore.showManageSubscriptions(in: windowScene)
                     }
                 }
-
-                Button {
-                    Task {
-                        retryProvisioningInProgress = true
-                        await subscriptionManager.retryRelayProvisioning(
-                            homeserverDeviceIDs: syncthingManager.devices.map(\.deviceID)
-                        )
-                        retryProvisioningInProgress = false
-                    }
-                } label: {
-                    HStack {
-                        Text("Retry Provisioning")
-                        Spacer()
-                        if retryProvisioningInProgress {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                    }
-                }
-                .disabled(retryProvisioningInProgress)
             } else {
                 if let product = subscriptionManager.availableProduct {
                     Button {

--- a/ios/VaultSync/Views/SettingsView.swift
+++ b/ios/VaultSync/Views/SettingsView.swift
@@ -148,7 +148,7 @@ struct SettingsView: View {
                                 .font(.caption2)
                                 .foregroundStyle(.secondary)
                             if let url = SyncUserError.troubleshootingURL(forRawError: reason) {
-                                Link("Learn how to fix", destination: url)
+                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                     .font(.caption2)
                             }
                         }
@@ -236,7 +236,7 @@ struct SettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.red)
                     if let url = SyncUserError.troubleshootingURL(forRawError: relayError) {
-                        Link("Learn how to fix", destination: url)
+                        ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                             .font(.caption2)
                     }
                 }
@@ -260,7 +260,7 @@ struct SettingsView: View {
 
     private var aboutSection: some View {
         Section("About") {
-            Link(destination: URL(string: "https://github.com/psimaker/vaultsync/blob/main/PRIVACY.md")!) {
+            Link(destination: DocURL.privacyPolicy) {
                 HStack {
                     Label("Privacy Policy", systemImage: "hand.raised")
                     Spacer()
@@ -271,7 +271,7 @@ struct SettingsView: View {
                 }
             }
 
-            Link(destination: URL(string: "https://github.com/psimaker/vaultsync/blob/main/TERMS.md")!) {
+            Link(destination: DocURL.termsOfUse) {
                 HStack {
                     Label("Terms of Use", systemImage: "doc.text")
                     Spacer()

--- a/ios/VaultSync/Views/SyncIssuesView.swift
+++ b/ios/VaultSync/Views/SyncIssuesView.swift
@@ -19,20 +19,23 @@ struct SyncIssuesView: View {
                             .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 3) {
-                            Text(issue.title)
-                                .font(.subheadline.weight(.semibold))
-                            Text(issue.message)
-                                .font(.caption)
-                            Text(issue.remediation)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(issue.title)
+                                    .font(.subheadline.weight(.semibold))
+                                Text(issue.message)
+                                    .font(.caption)
+                                Text(issue.remediation)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .accessibilityElement(children: .combine)
+
                             if let url = troubleshootingURL(for: issue.kind) {
-                                Link("Learn how to fix", destination: url)
+                                ExternalLinkButton(titleKey: "Learn how to fix", url: url)
                                     .font(.caption2)
                             }
                         }
                     }
-                    .accessibilityElement(children: .combine)
 
                     actionView(for: issue)
                 }
@@ -84,7 +87,7 @@ struct SyncIssuesView: View {
             Button("Accept First Pending Share") {
                 onAcceptFirstPendingShare()
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.bordered)
             .controlSize(.small)
             .disabled(syncthingManager.actionablePendingFolders.isEmpty)
 

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -495,3 +495,14 @@
 "Obsidian app cache" = "Obsidian-App-Cache";
 "Auto-regenerated Obsidian internal cache." = "Automatisch regenerierter interner Obsidian-Cache.";
 "Node modules" = "Node-Module";
+
+// Sync Issue titles & messages
+"1 Vault Has Sync Errors" = "1 Vault hat Synchronisationsfehler";
+"%d Vaults Have Sync Errors" = "%d Vaults haben Synchronisationsfehler";
+"At least one folder is currently in an error state." = "Mindestens ein Ordner befindet sich derzeit in einem Fehlerzustand.";
+"1 Required Device Is Disconnected" = "1 erforderliches Gerät ist getrennt";
+"%d Required Devices Are Disconnected" = "%d erforderliche Geräte sind getrennt";
+"1 Pending Share Needs Attention" = "1 ausstehende Freigabe benötigt Aufmerksamkeit";
+"%d Pending Shares Need Attention" = "%d ausstehende Freigaben benötigen Aufmerksamkeit";
+"1 Conflict Needs Resolution" = "1 Konflikt muss gelöst werden";
+"%d Conflicts Need Resolution" = "%d Konflikte müssen gelöst werden";

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -496,3 +496,14 @@
 "Obsidian app cache" = "Obsidian app cache";
 "Auto-regenerated Obsidian internal cache." = "Auto-regenerated Obsidian internal cache.";
 "Node modules" = "Node modules";
+
+// Sync Issue titles & messages
+"1 Vault Has Sync Errors" = "1 Vault Has Sync Errors";
+"%d Vaults Have Sync Errors" = "%d Vaults Have Sync Errors";
+"At least one folder is currently in an error state." = "At least one folder is currently in an error state.";
+"1 Required Device Is Disconnected" = "1 Required Device Is Disconnected";
+"%d Required Devices Are Disconnected" = "%d Required Devices Are Disconnected";
+"1 Pending Share Needs Attention" = "1 Pending Share Needs Attention";
+"%d Pending Shares Need Attention" = "%d Pending Shares Need Attention";
+"1 Conflict Needs Resolution" = "1 Conflict Needs Resolution";
+"%d Conflicts Need Resolution" = "%d Conflicts Need Resolution";

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -495,3 +495,14 @@
 "Obsidian app cache" = "Obsidian 应用缓存";
 "Auto-regenerated Obsidian internal cache." = "自动重建的 Obsidian 内部缓存。";
 "Node modules" = "Node 模块";
+
+// Sync Issue titles & messages
+"1 Vault Has Sync Errors" = "1 个 Vault 出现同步错误";
+"%d Vaults Have Sync Errors" = "%d 个 Vault 出现同步错误";
+"At least one folder is currently in an error state." = "至少有一个文件夹目前处于错误状态。";
+"1 Required Device Is Disconnected" = "1 台必需设备已断开连接";
+"%d Required Devices Are Disconnected" = "%d 台必需设备已断开连接";
+"1 Pending Share Needs Attention" = "1 个待处理共享需要处理";
+"%d Pending Shares Need Attention" = "%d 个待处理共享需要处理";
+"1 Conflict Needs Resolution" = "1 个冲突待解决";
+"%d Conflicts Need Resolution" = "%d 个冲突待解决";

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -50,8 +50,8 @@ targets:
     info:
       path: VaultSync/Info.plist
       properties:
-        CFBundleShortVersionString: "1.3.0"
-        CFBundleVersion: "22"
+        CFBundleShortVersionString: "1.3.1"
+        CFBundleVersion: "23"
         UILaunchScreen: {}
         UIApplicationSceneManifest:
           UIApplicationSupportsMultipleScenes: false
@@ -100,8 +100,8 @@ targets:
     info:
       path: VaultSyncWidget/Info.plist
       properties:
-        CFBundleShortVersionString: "1.3.0"
-        CFBundleVersion: "22"
+        CFBundleShortVersionString: "1.3.1"
+        CFBundleVersion: "23"
         CFBundleDisplayName: VaultSync Widget
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension


### PR DESCRIPTION
Closes #6.

## Summary

Two related fixes bundled together — a reported tap-collision bug on the home screen, plus the surrounding UI cleanup and translation gaps that surfaced while testing the fix.

### Bug fix — conflict button no longer also opens Safari (#6)

`SyncIssuesView` placed a `Link("Learn how to fix")` and a `NavigationLink("Resolve Conflicts")` in the same `List` row. In SwiftUI, a `NavigationLink` makes the entire row tappable, so any tap — even directly on the link — fired both gestures: navigation **and** browser open.

- New `ExternalLinkButton` helper: `Button` + `openURL` + `.buttonStyle(.borderless)` consumes taps and prevents the row-wide gesture from co-firing. Adds an `arrow.up.right` glyph to signal external destinations and a `contentShape` + vertical padding for hit-slop.
- Rolled out to all 12 `Link`-style spots across `ContentView`, `SettingsView`, `RelayDiagnosticsView`, `IgnorePatternsView` for consistency.
- Tightened `.accessibilityElement(children: .combine)` in `SyncIssuesView` so the link is its own VoiceOver target.
- Unified Sync Issue action-button styles: critical = `.borderedProminent`, warnings = `.bordered` (previously `pendingShares` was an outlier).
- Centralized 3 force-unwrapped doc URLs in a `DocURL` enum.

### Home screen polish

- Drop the `"VaultSync"` navigation title and keep the bar inline — reads as content, not chrome.
- Devices list no longer prints the long Device ID under each name. The full ID stays one tap away in the device detail view.

### Settings polish

- Cloud Relay: hide per-device provisioning rows when the device is already `.provisioned`. Only devices that need attention surface.
- Cloud Relay: remove the "Retry Provisioning" button. The same action remains available in Relay Diagnostics, where the advanced controls belong.
- "This Device" section: remove the standalone Device ID display. The "Copy Device ID" button is enough on its own.

### Translation gap

Reported case: the home-screen status `Synchronisierungsprobleme` showed `"1 Conflict Needs Resolution"` in English on a German locale. Root cause: the title strings for all four Sync Issue kinds were missing from every `Localizable.strings`, so `NSLocalizedString` was falling back to the key. Added 9 missing keys to `en` / `de` / `zh-Hans`:

- `1 Vault Has Sync Errors` / `%d Vaults Have Sync Errors`
- `At least one folder is currently in an error state.`
- `1 Required Device Is Disconnected` / `%d Required Devices Are Disconnected`
- `1 Pending Share Needs Attention` / `%d Pending Shares Need Attention`
- `1 Conflict Needs Resolution` / `%d Conflicts Need Resolution`

## Test plan

- [x] Existing test suite still passes (`SubscriptionManagerTests` still exercises `retryRelayProvisioning` against the manager directly — the method is unchanged, only the Settings UI entry point is removed).
- [ ] Manual: drop a `notes.sync-conflict-20260517-143022-ABCDEFG.md` next to a real file in a vault → wait for next poll → home screen shows the Sync Issues section → tap **Resolve Conflicts** → ConflictListView opens **without** the browser also launching.
- [ ] Manual: tap "Learn how to fix" in the same row → only the browser opens, no navigation.
- [ ] Manual: switch device language to German → with at least one conflict, the title reads "1 Konflikt muss gelöst werden" / "%d Konflikte müssen gelöst werden". Same check for `zh-Hans`.
- [ ] Manual: home screen no longer shows "VaultSync" title; device rows show only name + connected badge.
- [ ] Manual: Settings → Cloud Relay shows no per-device row when the only paired device is `Provisioned`; the "Retry Provisioning" button is gone.
- [ ] Manual: Settings → This Device shows only the "Copy Device ID" button (no inline ID block).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix: Prevent tap-collision bug and apply UI polish

This PR fixes issue `#6`, a tap-collision bug where tapping external documentation links in sync issue rows would also trigger the row's navigation action.

### Main Fix
Introduced a new `ExternalLinkButton` component (a borderless button with an external link arrow that opens URLs via `openURL`, with proper hit-slop handling) to replace shared-row `Link` instances. Rolled out across 5 views:
- `ContentView` (current sync error and per-vault folder error sections)
- `SyncIssuesView` (per-issue "Learn how to fix" links)
- `RelayDiagnosticsView` (relay troubleshooting links)
- `IgnorePatternsView` (filter documentation link)
- `SettingsView` (Cloud Relay troubleshooting and about links)

### UI Polish
- Removed "VaultSync" navigation title from home screen (kept inline bar display)
- Removed full Device ID from device list rows (ID remains accessible in device detail view and via "Copy Device ID" button)
- Simplified Cloud Relay provisioning UI: hide per-device rows when already `.provisioned`; removed standalone "Retry Provisioning" button from Settings (action remains in Relay Diagnostics)
- Centralized force-unwrapped doc URLs into a `DocURL` enum; updated Privacy Policy and Terms of Use links to use it

### Localization
Added 9 missing localization keys for Sync Issue titles and folder-error messages across English, German, and Simplified Chinese (en/de/zh-Hans), including singular/plural variants for conflicts, pending shares, disconnected devices, and sync errors.

### Test Coverage
Existing test suite passes. Manual UI test steps documented in PR.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psimaker/vaultsync/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->