### PR TITLE
ci: cost/correctness cleanup, security scanning, multi-arch image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  # Go bridge dependencies. The patched Syncthing and go-stun forks are local
+  # replace-shadowed copies pinned to a 2.x pseudo-version, so Dependabot can't
+  # reason about them — ignore to avoid noise. They are tracked manually against
+  # upstream security advisories (see go/patches/README.md).
+  - package-ecosystem: gomod
+    directory: /go
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: github.com/syncthing/syncthing
+      - dependency-name: github.com/ccding/go-stun
+
+  # GitHub Actions across all workflows. Also migrates mutable tags to commit
+  # SHAs and keeps them current once you pin them.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # notify relay container base images (golang:1.24-alpine, alpine:3.21).
+  # Dependabot will also propose @sha256 digest pins for these.
+  - package-ecosystem: docker
+    directory: /notify
+    schedule:
+      interval: weekly
+
+  # NOTE: /notify Go modules are intentionally not tracked — the relay is pure
+  # stdlib (no third-party require block), so there is nothing for gomod to bump.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [main]
+    # Docs/markdown-only commits don't affect the Go bridge or the iOS build, so
+    # skip the whole pipeline (incl. the ~10x-priced macOS build job) for them.
+    # NOTE: none of these jobs are required status checks yet. If you later enable
+    # branch protection requiring "Build & Test", replace paths-ignore with a
+    # per-job changed-files gate (dorny/paths-filter) so PRs don't hang waiting
+    # on a check that was skipped.
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +28,8 @@ permissions:
 jobs:
   go-tests:
     name: Go Tests
-    runs-on: macos-15
+    runs-on: ubuntu-latest # pure-Go bridge suite; needs no macOS/Xcode
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -31,32 +44,15 @@ jobs:
 
       - name: Run Go tests
         working-directory: go
+        # The status/event schema regression tests (Phase 1/3 fields, folder
+        # error details) live in ./bridge and run as part of this package — no
+        # separate runner needed.
         run: go test -tags noassets ./bridge -count=1
-
-  bridge-schema-regression:
-    name: Bridge Schema Regression
-    runs-on: macos-15
-    needs: go-tests
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go/go.mod
-          cache-dependency-path: go/go.sum
-
-      - name: Patch vendored dependencies
-        working-directory: go
-        run: make patch
-
-      - name: Run status/event schema regression tests
-        working-directory: go
-        run: |
-          go test -tags noassets ./bridge -count=1 -run 'Test(EventInfoUnmarshalMissingPhase3Fields|LegacyEventConsumerIgnoresPhase3Fields|FolderStatusUnmarshalMissingPhase1Fields|LegacyFolderStatusConsumerIgnoresPhase1Fields|GetFolderStatusJSONMissingFolderHasErrorDetails|BridgeEventDataFolderErrors)'
 
   notify-tests:
     name: Notify Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -70,10 +66,10 @@ jobs:
 
   build:
     name: Build & Test
-    runs-on: macos-26  # Xcode 26.2 default, iOS 26 SDK required for BGContinuedProcessingTask
+    runs-on: macos-26 # Xcode 26.2 default, iOS 26 SDK required for BGContinuedProcessingTask
+    timeout-minutes: 45 # guard against a hung simulator/xcodebuild burning 10x macOS minutes
     needs:
       - go-tests
-      - bridge-schema-regression
       - notify-tests
     steps:
       - uses: actions/checkout@v4
@@ -83,10 +79,18 @@ jobs:
           go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
 
+      - name: Cache gomobile toolchain
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/bin/gomobile
+            ~/go/bin/gobind
+          key: gomobile-${{ runner.os }}-3a7bc9f8a4de
+
       - name: Install gomobile
         run: |
-          go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20250305212854-3a7bc9f8a4de
-          go install golang.org/x/mobile/cmd/gobind@v0.0.0-20250305212854-3a7bc9f8a4de
+          command -v gomobile >/dev/null || go install golang.org/x/mobile/cmd/gomobile@v0.0.0-20250305212854-3a7bc9f8a4de
+          command -v gobind   >/dev/null || go install golang.org/x/mobile/cmd/gobind@v0.0.0-20250305212854-3a7bc9f8a4de
           gomobile init
 
       - name: Patch vendored dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,11 +15,14 @@ concurrency:
 permissions:
   contents: read
   packages: write
+  id-token: write # keyless build provenance attestation
+  attestations: write
 
 jobs:
   notify-guard:
     name: Notify Guard Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +37,14 @@ jobs:
   build-and-push:
     name: Build & Push
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: notify-guard
     steps:
       - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
         with:
@@ -53,8 +61,23 @@ jobs:
             type=match,pattern=notify-v(.*),group=1
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: notify
           push: true
+          platforms: linux/amd64,linux/arm64 # pure CGO_ENABLED=0 Go, arm64 self-host is a real target
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
+
+      # Push-then-scan: a HIGH/CRITICAL fixable CVE in the alpine base turns the
+      # run red so you know to bump the base. govulncheck (security.yml) covers
+      # the Go layer; only Trivy sees the OS packages.
+      - name: Scan published image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/psimaker/vaultsync-notify@${{ steps.build.outputs.digest }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,124 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+  schedule:
+    # Monday 06:00 UTC — surface CVEs disclosed against the vendored Syncthing
+    # fork or the alpine base even when the repo is quiet between releases.
+    # (GitHub pauses scheduled workflows after ~60 days of repo inactivity.)
+    - cron: "0 6 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  go-lint:
+    name: Go Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: notify/go.mod
+
+      # gofmt is dependency-free, so it checks the hand-written bridge package
+      # without materialising the patched Syncthing tree.
+      - name: gofmt
+        run: |
+          unformatted="$(gofmt -l go/bridge notify)"
+          if [ -n "$unformatted" ]; then
+            echo "::error::These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go vet (notify)
+        working-directory: notify
+        run: go vet ./...
+
+      # Optional next step: add golangci-lint here (golangci-lint-action@v9 needs
+      # golangci-lint v2 + a .golangci.yml). Left out for now so every check in
+      # this gate is verified-green.
+
+  govulncheck-go:
+    name: govulncheck (go bridge)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+
+      # Materialise the patched Syncthing/go-stun forks so govulncheck scans the
+      # code actually compiled into the app — the only scanner that sees CVEs
+      # inside the replace-shadowed fork.
+      - name: Patch vendored dependencies
+        working-directory: go
+        run: make patch
+
+      - name: govulncheck
+        working-directory: go
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck -tags noassets ./bridge/...
+
+  govulncheck-notify:
+    name: govulncheck (notify)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: notify/go.mod
+
+      - name: govulncheck
+        working-directory: notify
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
+  image-scan:
+    name: Image Scan (published)
+    # Catches base-image CVEs disclosed after the last build. Skipped on PRs
+    # (the PR's image isn't published yet); build-time scanning lives in
+    # docker.yml.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trivy scan of ghcr image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/psimaker/vaultsync-notify:latest
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"

--- a/go/bridge/pendingfolders.go
+++ b/go/bridge/pendingfolders.go
@@ -12,9 +12,9 @@ import (
 
 // PendingFolderInfo represents a folder offered by one or more remote devices.
 type PendingFolderInfo struct {
-	ID          string                `json:"id"`
-	Label       string                `json:"label"`
-	OfferedBy   []PendingDeviceInfo   `json:"offeredBy"`
+	ID        string              `json:"id"`
+	Label     string              `json:"label"`
+	OfferedBy []PendingDeviceInfo `json:"offeredBy"`
 }
 
 // PendingDeviceInfo identifies a device that offered a pending folder.

--- a/go/patches/README.md
+++ b/go/patches/README.md
@@ -1,0 +1,47 @@
+# Vendored fork patches & upstream security tracking
+
+VaultSync embeds a **patched copy** of two upstream Go modules. `make patch`
+(`../vendor-patch.sh`) regenerates them from the module cache and re-applies the
+patches below; the directories themselves (`go/_syncthing_patched`,
+`go/_go-stun_patched`) are gitignored and `replace`-shadowed in `go/go.mod`.
+
+## Why this needs manual attention
+
+Because the forks are gitignored and replaced by local directories, they are
+**invisible to graph-based scanners** (Dependabot, GitHub's dependency-graph
+advisory alerts). A CVE fixed upstream will **not** surface here automatically.
+Two safety nets compensate:
+
+- **`govulncheck`** (`.github/workflows/security.yml`) runs *after* `make patch`,
+  so it scans the patched source actually compiled into the app — the one
+  automated tool that sees inside the fork.
+- **This watch process** for advisories that haven't yet reached the Go vuln DB.
+
+## Pinned upstream
+
+| Module                          | Pin                                                       | Notes                          |
+| ------------------------------- | -------------------------------------------------------- | ------------------------------ |
+| `github.com/syncthing/syncthing` | `v1.30.0-rc.1.0.20260211104138-dc2a77ab8e5b` (commit `dc2a77ab8e5b`, 2026-02-11) | Pseudo-version of a 2.x build |
+| `github.com/ccding/go-stun`      | `v0.1.5`                                                  |                                |
+
+> The Syncthing pseudo-version reads like `v1.30.0-rc…` but the vendored module
+> is upstream **2.x** (see `_syncthing_patched/relnotes/v2.0.md`). Both modules
+> are `ignore`d in `.github/dependabot.yml` so Dependabot doesn't churn on them.
+
+## Patches
+
+- `syncthing/001-relay-client-nil-url.patch` — nil-URL guard in the relay client
+  (crash fix). **Security-relevant**: re-validate against Syncthing relay
+  advisories on each bump.
+- `syncthing/002-api-auto-noassets.patch` — build with `-tags noassets`.
+- `go-stun/001-nil-safe-host-methods.patch` — nil-safe host methods.
+
+## Before each release
+
+1. Check the upstream advisory pages:
+   - https://github.com/syncthing/syncthing/security/advisories
+   - https://github.com/ccding/go-stun/security/advisories
+   (Use **Watch → Custom → Security alerts** on both repos so they reach you.)
+2. If a fix lands, bump the `require` pin in `go/go.mod` (+ `go.sum`),
+   run `make patch`, and confirm the three patches still apply cleanly.
+3. Confirm `govulncheck` (security workflow) is green for `./bridge/...`.

--- a/go/vendor-patch.sh
+++ b/go/vendor-patch.sh
@@ -12,7 +12,10 @@ cd "$(dirname "$0")"
 # the original modules (they point to dirs that don't exist yet).
 echo "==> Temporarily removing replace directives..."
 cp go.mod go.mod.bak
-sed -i '' '/^replace /d' go.mod
+# Portable across BSD (macOS) and GNU (Linux) sed: rewrite via a temp file
+# instead of in-place editing, whose `-i` syntax differs between the two.
+# go.mod is restored from go.mod.bak below, so this only affects the download.
+grep -v '^replace ' go.mod > go.mod.tmp && mv go.mod.tmp go.mod
 
 echo "==> Downloading Go modules..."
 go mod download

--- a/notify/main_test.go
+++ b/notify/main_test.go
@@ -73,7 +73,6 @@ func TestLoadConfigRejectsInvalidDebounceSeconds(t *testing.T) {
 	}
 }
 
-
 func TestRunHealthcheckSkipsTriggerProbe(t *testing.T) {
 	var relayTriggerCalls atomic.Int32
 


### PR DESCRIPTION
## CI cost & correctness (ci.yml)
- Remove the redundant bridge-schema-regression job (its tests already run in go-tests) and drop it from build.needs.
- Make vendor-patch.sh sed portable; move go-tests to ubuntu-latest (pure Go, ~10x cheaper).
- Add timeout-minutes to every job; skip pipeline for docs-only changes; cache gomobile toolchain.

## Security (security.yml + dependabot.yml, new)
- gofmt + go vet gate; govulncheck for the go bridge (after make patch, sees the vendored Syncthing fork) and notify; weekly Trivy image scan.
- Dependabot for go modules, GitHub Actions, and the notify Docker base. Patched syncthing/go-stun forks are ignored (2.x pseudo-version).
- go/patches/README.md documents the upstream-advisory watch process for the gitignored, replace-shadowed forks.

## Docker (docker.yml)
- Multi-arch amd64+arm64, max provenance + SBOM attestations, Trivy scan of the built image by digest.

First CI run is the real integration test for the ubuntu/make-patch move and govulncheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enhances CI/security infrastructure and Docker build pipelines without affecting runtime sync behavior.

## Security & Vulnerability Scanning
- Adds security workflow with static analysis gates (gofmt, go vet) and `govulncheck` scanning for Go code post-vendoring to catch vulnerabilities in patched dependencies
- Introduces weekly Trivy image scans and post-build Trivy scanning of Docker images, failing on unfixed HIGH/CRITICAL vulnerabilities
- Configures Dependabot to check Go modules, GitHub Actions, and Docker dependencies weekly, with exclusions for patched forks (syncthing/go-stun)
- Documents upstream security advisory monitoring process for vendored/patched forks in `go/patches/README.md`

## CI/Build Improvements
- Moves Go tests to `ubuntu-latest` (cost reduction for pure Go tests while macOS/iOS tests remain on macOS)
- Adds `timeout-minutes` to all jobs for resource protection
- Caches gomobile toolchain to reduce build time
- Makes `vendor-patch.sh` sed operations portable across Linux and macOS
- Skips entire pipeline for documentation-only changes
- Removes redundant bridge-schema-regression job dependency

## Docker
- Enables multi-architecture builds (linux/amd64 + linux/arm64) via QEMU and Buildx
- Adds maximum provenance and SBOM attestations for built images

No changes to user-facing sync functionality or runtime behavior. Changes are infrastructure-focused with emphasis on supply chain security and cost optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->