### PR TITLE
fix(ci): run published-image scan on schedule only

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -99,10 +99,12 @@ jobs:
 
   image-scan:
     name: Image Scan (published)
-    # Catches base-image CVEs disclosed after the last build. Skipped on PRs
-    # (the PR's image isn't published yet); build-time scanning lives in
-    # docker.yml.
-    if: github.event_name != 'pull_request'
+    # Schedule only: catches base-image / Go-binary CVEs disclosed against the
+    # published image after the last build, without a commit. Build-time scanning
+    # (the moment the image changes) is owned by docker.yml. Running this on push
+    # would only race the docker.yml rebuild on the same commit and scan a stale
+    # :latest.
+    if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
The image-scan job raced the docker.yml rebuild on push and flagged the stale pre-fix image. Build-time scanning is owned by docker.yml; gate this job on the schedule event only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

Modified `.github/workflows/security.yml` to restrict the `image-scan` job to run only on scheduled events (weekly on Mondays at 06:00 UTC) instead of running on every push.

## Security Impact

This change prevents false-negative security reports. Previously, the image scan could execute before the Docker build completed and published a new image, scanning a stale `:latest` tag and missing freshly discovered CVEs in base images or Go binaries. Build-time scanning (scanning freshly built images by digest) is handled separately in `docker.yml`. The scheduled-only approach now performs weekly rescans of the published image to catch CVEs disclosed after the last build, while eliminating unproductive scan races with the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->