### PR TITLE
ci: add PR-title lint, version check, and PR/issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Report a problem with VaultSync (iOS app, bridge, or relay)
+labels: [bug]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - iOS app
+        - Widget
+        - go bridge / Syncthing
+        - notify relay
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: VaultSync version & build
+      description: Settings → About (e.g. 1.4.0 build 25)
+      placeholder: "1.4.0 (25)"
+    validations:
+      required: true
+  - type: input
+    id: ios_version
+    attributes:
+      label: iOS version & device
+      placeholder: "iOS 26.2, iPhone 15 Pro"
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: What did you do, what did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Optional — anything that helps narrow it down.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- PR titles follow Conventional Commits (feat:, fix:, docs:, chore:, ci: …);
+     PRs are squash-merged, so the title becomes the commit subject on main. -->
+
+## What & why
+<!-- One or two sentences: what changes and why. Link the issue if there is one. -->
+
+## Component(s)
+- [ ] go (bridge / Syncthing)
+- [ ] ios (app / widget)
+- [ ] notify (relay)
+- [ ] docs / CI
+
+## Testing
+- [ ] `cd go && make patch && go test -tags noassets ./bridge`
+- [ ] `cd notify && go test ./...`
+- [ ] iOS build / `xcodebuild test`
+- [ ] Not applicable

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,37 @@
+name: PR Title
+
+# PRs are squash-merged, so the PR title becomes the commit subject on main.
+# Enforce Conventional Commits on the title (the convention README declares).
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  pr-title:
+    name: PR Title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            ci
+            perf
+            build
+            style
+            revert

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,29 @@
+name: Version Check
+
+# Runs when a release tag is pushed. Can't block the tag (it already exists),
+# but turns the run red if the version in the tag, ios/project.yml and the
+# CHANGELOG don't agree — catching a forgotten bump before you cut the release.
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    name: Version Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Tag matches project.yml and CHANGELOG
+        run: |
+          V="${GITHUB_REF_NAME#v}"
+          echo "Releasing version: $V"
+          grep -q "CFBundleShortVersionString: \"$V\"" ios/project.yml \
+            || { echo "::error::ios/project.yml CFBundleShortVersionString does not match tag $V"; exit 1; }
+          grep -q "^## \[$V\]" CHANGELOG.md \
+            || { echo "::error::CHANGELOG.md has no '## [$V]' section for tag $V"; exit 1; }
+          echo "OK — tag, ios/project.yml and CHANGELOG.md all agree on $V"


### PR DESCRIPTION
Adds a Conventional-Commits PR-title check (squash-merge surface), a tag-triggered version-consistency guard (tag vs ios/project.yml vs CHANGELOG), and a minimal PR template + bug-report issue form.