### PR TITLE
ci(dependabot): group action updates and auto-merge minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,57 @@ updates:
   # replace-shadowed copies pinned to a 2.x pseudo-version, so Dependabot can't
   # reason about them — ignore to avoid noise. They are tracked manually against
   # upstream security advisories (see go/patches/README.md).
+  # NOT auto-merged: a behaviour regression in the native bridge needs human
+  # judgement even when Go Tests + govulncheck are green.
   - package-ecosystem: gomod
     directory: /go
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Let a freshly-cut release settle before filing a PR, so we skip the churn
+    # of x.y.0 -> x.y.1 same-week re-bumps.
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: github.com/syncthing/syncthing
       - dependency-name: github.com/ccding/go-stun
 
-  # GitHub Actions across all workflows. Also migrates mutable tags to commit
-  # SHAs and keeps them current once you pin them.
+  # GitHub Actions across all workflows. Grouped into ONE weekly PR, split so the
+  # auto-merge workflow (.github/workflows/dependabot-auto-merge.yml) can act on
+  # minor/patch only — those are the bumps actually exercised by the PR's
+  # required checks (ci.yml + security.yml run on pull_request). Majors land in a
+  # separate PR for manual review, because actions used only in docker.yml /
+  # version-check.yml are NOT run on pull_request, so a green PR proves nothing
+  # about them. Also migrates mutable tags to commit SHAs once you pin them.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:
+        patterns: ["*"]
+        update-types: ["major"]
+    # Let a tag age before adopting it; bad action releases are usually
+    # yanked/fixed within a day or two.
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 3
 
-  # notify relay container base images (golang:1.24-alpine, alpine:3.21).
+  # notify relay container base images (golang:1.26-alpine, alpine:3.23).
   # Dependabot will also propose @sha256 digest pins for these.
+  # NOT auto-merged: docker.yml (build + multi-arch + Trivy scan) runs only on
+  # push/tag, never on pull_request, so a base-image bump PR is never actually
+  # built or scanned. Review by building/scanning locally first.
   - package-ecosystem: docker
     directory: /notify
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   # NOTE: /notify Go modules are intentionally not tracked — the relay is pure
   # stdlib (no third-party require block), so there is nothing for gomod to bump.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,47 @@
+name: Dependabot auto-merge
+
+# Enables GitHub native auto-merge for low-risk Dependabot PRs only:
+# github-actions MINOR/PATCH bumps. Those are the bumps actually exercised by
+# the PR's required checks (ci.yml + security.yml run on pull_request), so a
+# green PR is meaningful for them.
+#
+# Deliberately NOT auto-merged — left for weekly manual review — because their
+# changed code never runs on a pull_request, so a green PR proves nothing:
+#   - github-actions MAJOR bumps (input / Node-runtime / behaviour changes)
+#   - gomod                      (native bridge; judgement call)
+#   - /notify base images        (docker.yml builds + Trivy-scans only on push/tag)
+#
+# `--auto` hands the merge to GitHub, which still blocks on the branch-protection
+# required checks (Go Tests, Notify Tests, PR Title). No approval step is needed:
+# main's protection requires status checks, not reviews.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # For a grouped PR, update-type reflects the HIGHEST bump in the group, so
+      # the actions-minor-patch group reports minor/patch and merges, while the
+      # actions-major group reports major and is held for review. Matching on the
+      # branch prefix avoids any github_actions vs github-actions naming ambiguity.
+      - name: Enable auto-merge (github-actions minor/patch only)
+        if: >-
+          startsWith(github.head_ref, 'dependabot/github_actions/') &&
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' ||
+           steps.meta.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Group all github-actions bumps into one weekly PR (minor/patch auto-mergeable, majors manual). Add native auto-merge workflow scoped to github-actions minor/patch, gated on dependabot[bot]. Majors, gomod and /notify base images stay on manual review because docker.yml/version-check.yml don't run on pull_request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## CI/Dependabot: Auto-merge GitHub Actions minor/patch updates

Configures Dependabot to group GitHub Actions dependency updates into weekly PRs and automatically merge low-risk changes:

**Changes:**
- Updated `.github/dependabot.yml` to split GitHub Actions updates into two groups: `actions-minor-patch` (auto-mergeable) and `actions-major` (manual review)
- Introduced cooldown periods across all ecosystems (3–14 days for actions, 7 days for Go modules and Docker) to prevent same-week re-bump churn
- Added `.github/workflows/dependabot-auto-merge.yml` to enable GitHub native auto-merge (squash strategy) exclusively for GitHub Actions minor/patch PRs via `gh pr merge --auto`

**Scope:**
Auto-merge is limited to minor/patch updates because these are exercised by required checks (Go Tests, Notify Tests) that run on pull_request. Major action bumps, Go module updates, and base-image changes remain manual since the checks that would validate them (docker.yml, version-check.yml) do not run on pull_request events.

**Gating:**
The workflow respects existing branch protection rules—no approval step required, as main's protection enforces status checks rather than reviews.

No impact on user-facing functionality, privacy, security, or background sync behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->