### PR TITLE
ci: stop docs-only PRs hanging on required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    # Docs/markdown-only commits don't affect the Go bridge or the iOS build, so
-    # skip the whole pipeline (incl. the ~10x-priced macOS build job) for them.
-    # NOTE: none of these jobs are required status checks yet. If you later enable
-    # branch protection requiring "Build & Test", replace paths-ignore with a
-    # per-job changed-files gate (dorny/paths-filter) so PRs don't hang waiting
-    # on a check that was skipped.
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +14,37 @@ permissions:
   contents: read
 
 jobs:
+  # The required checks (Go Tests, Notify Tests) are cheap ubuntu jobs and ALWAYS
+  # run, so branch-protection PRs never hang on a never-reported status — the trap
+  # a bare top-level `paths-ignore:` creates once a job is a required check (a
+  # path-filtered *workflow* stays "Expected" forever, blocking the PR). Instead
+  # the only thing gated is the ~10x-priced macOS "Build & Test" job, on whether
+  # any non-docs file changed, detected here.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read # dorny lists PR files via the API (no checkout here)
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          # "code" = anything that can affect the Go bridge or the iOS build.
+          # Docs-only changes (**/*.md, docs/**, LICENSE, …) match nothing here,
+          # so the macOS build is skipped. Add new top-level code trees here if
+          # the repo layout grows. (Per-pattern OR semantics make a "!docs/**"
+          # negation list unreliable, hence the positive allow-list.)
+          filters: |
+            code:
+              - 'go/**'
+              - 'ios/**'
+              - 'notify/**'
+              - '.github/**'
+
   go-tests:
     name: Go Tests
     runs-on: ubuntu-latest # pure-Go bridge suite; needs no macOS/Xcode
@@ -81,9 +100,15 @@ jobs:
     runs-on: macos-26 # Xcode 26.2 default, iOS 26 SDK required for BGContinuedProcessingTask
     timeout-minutes: 45 # guard against a hung simulator/xcodebuild burning 10x macOS minutes
     needs:
+      - changes
       - go-tests
       - notify-tests
       - design-lint
+    # Skip the expensive macOS build on docs-only changes. It is not a required
+    # status check, so skipping never blocks a PR. The plain expression (no
+    # always()/status function) keeps the implicit "all needs succeeded" gate,
+    # so a failed test job still skips the build exactly as before.
+    if: needs.changes.outputs.code == 'true'
     steps:
       - uses: actions/checkout@v6
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Your notes sync peer-to-peer over Syncthing, straight into Obsidian's iOS sandbo
 
 ## 🧭 How it works
 
-```mermaid
-flowchart LR
-    S["🖥️ Your Mac / Linux / NAS<br/>+ Syncthing"] <-->|"Syncthing protocol<br/>LAN or Internet"| A["📱 VaultSync<br/>iOS / iPadOS"]
-    A --> O["📝 Obsidian vault<br/>iOS sandbox"]
-    S -. "optional sidecar<br/>vaultsync-notify" .-> R["☁️ relay.vaultsync.eu"]
-    R -. "APNs silent push<br/>wake-up only" .-> A
-```
+<div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/images/vaultsync-architecture-dark.svg">
+  <img alt="VaultSync architecture: your server with Syncthing syncs peer-to-peer with the VaultSync iOS app, which writes notes into your Obsidian vault. An optional Cloud Relay sends silent push wake-ups." src="docs/images/vaultsync-architecture-light.svg" width="100%">
+</picture>
+
+</div>
 
 Syncthing runs on a machine you keep on; VaultSync joins as a peer and syncs into Obsidian. The optional sidecar + Cloud Relay wake your iPhone when the server changes.
 

--- a/docs/images/vaultsync-architecture-dark.svg
+++ b/docs/images/vaultsync-architecture-dark.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 460" width="940" height="460" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" role="img" aria-label="VaultSync architecture: your server running Syncthing syncs peer-to-peer with the VaultSync iOS app, which places notes into your Obsidian vault. An optional Cloud Relay sends silent push wake-ups to the app.">
+  <defs>
+    <marker id="arrTeal" viewBox="0 0 10 10" refX="8.2" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2fc1bf"/>
+    </marker>
+    <marker id="arrMuted" viewBox="0 0 10 10" refX="8.2" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#6b7682"/>
+    </marker>
+  </defs>
+
+  <!-- EDGES (drawn first, boxes overlay the ends) -->
+  <!-- Server <-> VaultSync : core sync, bidirectional -->
+  <path d="M258,322 H362" fill="none" stroke="#2fc1bf" stroke-width="2.5" marker-start="url(#arrTeal)" marker-end="url(#arrTeal)"/>
+  <!-- VaultSync -> Obsidian -->
+  <path d="M578,322 H682" fill="none" stroke="#2fc1bf" stroke-width="2.5" marker-end="url(#arrTeal)"/>
+  <!-- Server -> Relay : optional sidecar (dashed) -->
+  <path d="M150,268 C150,205 192,138 243,136" fill="none" stroke="#6b7682" stroke-width="2" stroke-dasharray="5 5" marker-end="url(#arrMuted)"/>
+  <!-- Relay -> VaultSync : APNs wake-up (dashed) -->
+  <path d="M372,136 C420,182 470,196 470,268" fill="none" stroke="#6b7682" stroke-width="2" stroke-dasharray="5 5" marker-end="url(#arrMuted)"/>
+
+  <!-- EDGE LABELS -->
+  <text x="310" y="284" text-anchor="middle" font-size="11" fill="#c9d1d9">Syncthing protocol</text>
+  <text x="310" y="299" text-anchor="middle" font-size="11" fill="#9aa6b2">LAN or Internet</text>
+  <text x="630" y="310" text-anchor="middle" font-size="11" fill="#9aa6b2">into the vault</text>
+  <text x="100" y="200" text-anchor="middle" font-size="10.5" fill="#9aa6b2">optional sidecar</text>
+  <text x="100" y="214" text-anchor="middle" font-size="10.5" fill="#9aa6b2">vaultsync-notify</text>
+  <text x="566" y="190" text-anchor="middle" font-size="10.5" fill="#9aa6b2">APNs silent push</text>
+  <text x="566" y="204" text-anchor="middle" font-size="10.5" fill="#9aa6b2">wake-up only</text>
+
+  <!-- SERVER -->
+  <g transform="translate(44,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#161b22" stroke="#2a313a" stroke-width="1.5"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#21262d"/>
+    <g fill="none" stroke="#9aa6b2" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="25" y="41" width="22" height="8.5" rx="2"/>
+      <rect x="25" y="54.5" width="22" height="8.5" rx="2"/>
+    </g>
+    <circle cx="42" cy="45.25" r="1.5" fill="#9aa6b2"/>
+    <circle cx="42" cy="58.75" r="1.5" fill="#9aa6b2"/>
+    <text x="68" y="46" font-size="15" font-weight="600" fill="#e6edf3">Your server</text>
+    <text x="68" y="64" font-size="11.5" fill="#9aa6b2">Mac · Linux · NAS</text>
+    <text x="68" y="81" font-size="11.5" fill="#9aa6b2">+ Syncthing</text>
+  </g>
+
+  <!-- VAULTSYNC (hero) -->
+  <g transform="translate(364,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#11302f" stroke="#2fc1bf" stroke-width="2"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#14403e"/>
+    <g fill="none" stroke="#4fd6d3" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="29" y="38" width="14" height="28" rx="3"/>
+      <line x1="33" y1="62.5" x2="39" y2="62.5"/>
+      <path d="M32.4,47.2 A3.7,3.7 0 0 1 39.4,46.6"/>
+      <path d="M39.6,50.8 A3.7,3.7 0 0 1 32.6,51.4"/>
+    </g>
+    <path d="M39.4,46.6 l1.3,-1.0 l-0.2,2.0 z" fill="#4fd6d3"/>
+    <path d="M32.6,51.4 l-1.3,1.0 l0.2,-2.0 z" fill="#4fd6d3"/>
+    <text x="68" y="50" font-size="16" font-weight="700" fill="#d7faf8">VaultSync</text>
+    <text x="68" y="69" font-size="11.5" fill="#6fd3d0">iOS · iPadOS</text>
+  </g>
+
+  <!-- OBSIDIAN -->
+  <g transform="translate(684,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#161b22" stroke="#2a313a" stroke-width="1.5"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#21262d"/>
+    <g fill="none" stroke="#9aa6b2" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M28,38 h11 l7,7 v17 a2,2 0 0 1 -2,2 h-16 a2,2 0 0 1 -2,-2 v-22 a2,2 0 0 1 2,-2 z"/>
+      <path d="M39,38 v7 h7"/>
+      <line x1="31" y1="50" x2="42" y2="50"/>
+      <line x1="31" y1="54.5" x2="42" y2="54.5"/>
+      <line x1="31" y1="59" x2="38" y2="59"/>
+    </g>
+    <text x="68" y="50" font-size="15" font-weight="600" fill="#e6edf3">Obsidian vault</text>
+    <text x="68" y="69" font-size="11.5" fill="#9aa6b2">iOS sandbox</text>
+  </g>
+
+  <!-- RELAY (optional) -->
+  <g transform="translate(208,40)">
+    <rect x="0" y="0" width="204" height="96" rx="16" fill="#161b22" stroke="#39424c" stroke-width="1.5" stroke-dasharray="5 5"/>
+    <rect x="16" y="30" width="36" height="36" rx="10" fill="#21262d"/>
+    <path d="M25,53 a5.3,5.3 0 0 1 0.7,-10.4 a6.5,6.5 0 0 1 12.2,-1 a4.7,4.7 0 0 1 1.1,11.4 z" fill="none" stroke="#9aa6b2" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="64" y="39" font-size="9" font-weight="700" letter-spacing="0.8" fill="#2fc1bf">OPTIONAL</text>
+    <text x="64" y="57" font-size="14" font-weight="600" fill="#e6edf3">Cloud Relay</text>
+    <text x="64" y="74" font-size="10.5" fill="#9aa6b2">relay.vaultsync.eu</text>
+  </g>
+</svg>

--- a/docs/images/vaultsync-architecture-light.svg
+++ b/docs/images/vaultsync-architecture-light.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 940 460" width="940" height="460" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif" role="img" aria-label="VaultSync architecture: your server running Syncthing syncs peer-to-peer with the VaultSync iOS app, which places notes into your Obsidian vault. An optional Cloud Relay sends silent push wake-ups to the app.">
+  <defs>
+    <marker id="arrTeal" viewBox="0 0 10 10" refX="8.2" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#2AB5B3"/>
+    </marker>
+    <marker id="arrMuted" viewBox="0 0 10 10" refX="8.2" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#9aa4af"/>
+    </marker>
+  </defs>
+
+  <!-- EDGES (drawn first, boxes overlay the ends) -->
+  <!-- Server <-> VaultSync : core sync, bidirectional -->
+  <path d="M258,322 H362" fill="none" stroke="#2AB5B3" stroke-width="2.5" marker-start="url(#arrTeal)" marker-end="url(#arrTeal)"/>
+  <!-- VaultSync -> Obsidian -->
+  <path d="M578,322 H682" fill="none" stroke="#2AB5B3" stroke-width="2.5" marker-end="url(#arrTeal)"/>
+  <!-- Server -> Relay : optional sidecar (dashed) -->
+  <path d="M150,268 C150,205 192,138 243,136" fill="none" stroke="#9aa4af" stroke-width="2" stroke-dasharray="5 5" marker-end="url(#arrMuted)"/>
+  <!-- Relay -> VaultSync : APNs wake-up (dashed) -->
+  <path d="M372,136 C420,182 470,196 470,268" fill="none" stroke="#9aa4af" stroke-width="2" stroke-dasharray="5 5" marker-end="url(#arrMuted)"/>
+
+  <!-- EDGE LABELS -->
+  <text x="310" y="284" text-anchor="middle" font-size="11" fill="#424a53">Syncthing protocol</text>
+  <text x="310" y="299" text-anchor="middle" font-size="11" fill="#57606a">LAN or Internet</text>
+  <text x="630" y="310" text-anchor="middle" font-size="11" fill="#57606a">into the vault</text>
+  <text x="100" y="200" text-anchor="middle" font-size="10.5" fill="#57606a">optional sidecar</text>
+  <text x="100" y="214" text-anchor="middle" font-size="10.5" fill="#57606a">vaultsync-notify</text>
+  <text x="566" y="190" text-anchor="middle" font-size="10.5" fill="#57606a">APNs silent push</text>
+  <text x="566" y="204" text-anchor="middle" font-size="10.5" fill="#57606a">wake-up only</text>
+
+  <!-- SERVER -->
+  <g transform="translate(44,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#fff" stroke="#d8dee4" stroke-width="1.5"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#f3f5f7"/>
+    <g fill="none" stroke="#57606a" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="25" y="41" width="22" height="8.5" rx="2"/>
+      <rect x="25" y="54.5" width="22" height="8.5" rx="2"/>
+    </g>
+    <circle cx="42" cy="45.25" r="1.5" fill="#57606a"/>
+    <circle cx="42" cy="58.75" r="1.5" fill="#57606a"/>
+    <text x="68" y="46" font-size="15" font-weight="600" fill="#1f2328">Your server</text>
+    <text x="68" y="64" font-size="11.5" fill="#57606a">Mac · Linux · NAS</text>
+    <text x="68" y="81" font-size="11.5" fill="#57606a">+ Syncthing</text>
+  </g>
+
+  <!-- VAULTSYNC (hero) -->
+  <g transform="translate(364,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#e9f8f7" stroke="#2AB5B3" stroke-width="2"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#d4f1ef"/>
+    <g fill="none" stroke="#1b9e9c" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="29" y="38" width="14" height="28" rx="3"/>
+      <line x1="33" y1="62.5" x2="39" y2="62.5"/>
+      <path d="M32.4,47.2 A3.7,3.7 0 0 1 39.4,46.6"/>
+      <path d="M39.6,50.8 A3.7,3.7 0 0 1 32.6,51.4"/>
+    </g>
+    <path d="M39.4,46.6 l1.3,-1.0 l-0.2,2.0 z" fill="#1b9e9c"/>
+    <path d="M32.6,51.4 l-1.3,1.0 l0.2,-2.0 z" fill="#1b9e9c"/>
+    <text x="68" y="50" font-size="16" font-weight="700" fill="#0f1b1a">VaultSync</text>
+    <text x="68" y="69" font-size="11.5" fill="#1b6360">iOS · iPadOS</text>
+  </g>
+
+  <!-- OBSIDIAN -->
+  <g transform="translate(684,270)">
+    <rect x="0" y="0" width="212" height="104" rx="16" fill="#fff" stroke="#d8dee4" stroke-width="1.5"/>
+    <rect x="18" y="34" width="36" height="36" rx="10" fill="#f3f5f7"/>
+    <g fill="none" stroke="#57606a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M28,38 h11 l7,7 v17 a2,2 0 0 1 -2,2 h-16 a2,2 0 0 1 -2,-2 v-22 a2,2 0 0 1 2,-2 z"/>
+      <path d="M39,38 v7 h7"/>
+      <line x1="31" y1="50" x2="42" y2="50"/>
+      <line x1="31" y1="54.5" x2="42" y2="54.5"/>
+      <line x1="31" y1="59" x2="38" y2="59"/>
+    </g>
+    <text x="68" y="50" font-size="15" font-weight="600" fill="#1f2328">Obsidian vault</text>
+    <text x="68" y="69" font-size="11.5" fill="#57606a">iOS sandbox</text>
+  </g>
+
+  <!-- RELAY (optional) -->
+  <g transform="translate(208,40)">
+    <rect x="0" y="0" width="204" height="96" rx="16" fill="#fff" stroke="#cfd6dd" stroke-width="1.5" stroke-dasharray="5 5"/>
+    <rect x="16" y="30" width="36" height="36" rx="10" fill="#f3f5f7"/>
+    <path d="M25,53 a5.3,5.3 0 0 1 0.7,-10.4 a6.5,6.5 0 0 1 12.2,-1 a4.7,4.7 0 0 1 1.1,11.4 z" fill="none" stroke="#57606a" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="64" y="39" font-size="9" font-weight="700" letter-spacing="0.8" fill="#2AB5B3">OPTIONAL</text>
+    <text x="64" y="57" font-size="14" font-weight="600" fill="#1f2328">Cloud Relay</text>
+    <text x="64" y="74" font-size="10.5" fill="#57606a">relay.vaultsync.eu</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What & why

Two related changes — the docs change surfaced a latent CI problem, so both are fixed here.

### Docs — architecture diagram
Replace the Mermaid `flowchart` in the README with two hand-authored, theme-aware SVGs
(`docs/images/vaultsync-architecture-{dark,light}.svg`), served via `<picture>` + `prefers-color-scheme`. Crisper
rendering, proper dark/light variants, and a full `aria-label`/`alt` description.

### CI — stop docs-only PRs hanging on required checks
The required status checks **Go Tests** and **Notify Tests** live in `ci.yml`, which was skipped entirely on
docs/markdown-only changes via a top-level `paths-ignore`. Once those jobs became required in branch protection, such
PRs hung forever on *"Expected — waiting for status to be reported"* (a path-filtered workflow never reports a
status). This PR itself hit that.

**Fix:**
- Drop `paths-ignore` so the workflow always triggers; the cheap ubuntu required checks (`Go Tests`, `Notify Tests`)
  now always report green — no reliance on skipped-check semantics.
- Gate only the ~10x-priced macOS **Build & Test** job behind a `dorny/paths-filter` `code` detector (`go/**`,
  `ios/**`, `notify/**`, `.github/**`). Docs-only changes still skip the costly build; it is not a required check, so
  skipping never blocks a PR.
- The plain `if:` expression (no `always()`) keeps the implicit "all needs succeeded" gate, so a failed test job still
  skips the build as before.

## Notes
Because this branch touches `.github/**`, the `code` filter is `true` for this PR, so the macOS build runs once here
to validate the CI change itself.
