### PR TITLE
ci: checkout before paths-filter so push-to-main runs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,15 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read # dorny lists PR files via the API (no checkout here)
+      pull-requests: read # dorny lists PR files via the API on pull_request events
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
+      # Required for push events (e.g. merge to main): with no PR to query, dorny
+      # falls back to a local git diff and needs a working copy. On pull_request
+      # it uses the API, but the checkout is harmless there.
+      - uses: actions/checkout@v6
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:


### PR DESCRIPTION
## Problem

The `CI` run for the merge of #34 to `main` failed in the **Detect changes** job:


```

[command]/usr/bin/git branch --show-current
fatal: not a git repository (or any of the parent directories): .git
The process '/usr/bin/git' failed with exit code 128

```

## Cause

The `changes` job ran `dorny/paths-filter@v3` **without a checkout**. That is fine on `pull_request` events, where paths-filter lists changed files via the GitHub API. But on `push` events (the merge to `main`) there is no PR to query, so it falls back to a local git diff and needs a working copy. With no `.git` present, its first git command fails with exit code 128.

This surfaced only after merge: #34 introduced the `changes` job itself, and push-to-main was the first `push` event to exercise it. The PR checks passed because they ran on `pull_request`.

## Fix

Add `actions/checkout@v6` as the first step of the `changes` job so it works on both `push` and `pull_request`. Also updated the now-misleading comment.

## Impact

- Required checks (Go Tests, Notify Tests, Design Token Lint) were already green, so branch protection was never blocked.
- The macOS **Build & Test** job was wrongly skipped on the failing run; with the checkout in place it is gated correctly again.