### PR TITLE
fix(notify): upgrade Alpine base packages in the image build

### DIFF
--- a/notify/Dockerfile
+++ b/notify/Dockerfile
@@ -4,7 +4,10 @@ COPY go.mod *.go ./
 RUN CGO_ENABLED=0 go build -o /vaultsync-notify
 
 FROM alpine:3.23
-RUN apk add --no-cache ca-certificates && \
+# Upgrade base packages: security fixes often land in the apk repos before
+# the alpine base image is re-released (e.g. CVE-2026-45447 in libcrypto3).
+RUN apk --no-cache upgrade && \
+    apk add --no-cache ca-certificates && \
     adduser -D -H appuser
 COPY --from=builder /vaultsync-notify /usr/local/bin/
 USER appuser


### PR DESCRIPTION
The post-push Trivy scan failed on CVE-2026-45447 (HIGH): alpine:3.23 still ships libcrypto3/libssl3 3.5.6-r0 while the fixed 3.5.7-r0 is already in the apk repos. Running apk upgrade in the runtime stage picks up security fixes without waiting for a re-released base image. Verified locally: the built image contains 3.5.7-r0. Exploitability was nil either way — the helper is a static Go binary that never links OpenSSL.