### PR TITLE
feat(ios): enable the approved multicast networking entitlement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to VaultSync are documented here.
 - **Pasting a block of sync filters now works** ([#43](https://github.com/psimaker/vaultsync/issues/43)) — the Sync Filters "Add pattern" field was single-line, so pasting a multi-line list of patterns collapsed into one unusable entry — and because such a paste usually begins with a `//` comment, it silently matched nothing. The field is now multi-line and adds **one pattern per line**: blank lines and `//` comments are skipped, and patterns that contain spaces stay intact.
 - **Editing one filter no longer reshuffles the rest** — removing a custom pattern, or turning off a detected one, used to rewrite the entire `.stignore` in an arbitrary order. Syncthing applies patterns top to bottom (so an earlier `!`-include can override a later rule), so the original line order is now preserved on every change.
 
+### Changed
+
+- **More reliable local discovery on the same Wi-Fi** — now that Apple has approved the multicast networking entitlement, VaultSync uses multicast for Syncthing's local peer discovery, so your other devices on the same network are found directly and quickly instead of leaning on global discovery or a relay. This completes the local-network work started in 1.7.0 (the Local Network permission and direct dialing).
+
 ## [1.7.0] — 2026-06-12
 
 ### Added

--- a/ios/VaultSync/VaultSync.entitlements
+++ b/ios/VaultSync/VaultSync.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.networking.multicast</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.eu.vaultsync.shared</string>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -78,8 +78,8 @@ targets:
         # TCP/QUIC dials to peers on the same Wi-Fi, forcing every connection
         # through public relays — the slowest reconnect path after a cold start.
         # (Syncthing's multicast *discovery* additionally needs the restricted
-        # com.apple.developer.networking.multicast entitlement, which requires
-        # Apple approval — see docs/architecture.md.)
+        # com.apple.developer.networking.multicast entitlement — Apple-approved
+        # for this App ID and enabled in the entitlements below; see docs/architecture.md.)
         NSLocalNetworkUsageDescription: "VaultSync connects directly to your other devices on the same network so your vaults sync instantly, without a detour through the internet."
         # NOTE: NSAppTransportSecurity is deliberately NOT set, so shipping (Release)
         # builds keep the strictest ATS posture. The production app only talks HTTPS to
@@ -106,6 +106,9 @@ targets:
         aps-environment: development
         com.apple.security.application-groups:
           - group.eu.vaultsync.shared
+        # Apple-approved restricted entitlement: lets Syncthing's local discovery
+        # use multicast so same-Wi-Fi peers are found directly, without a relay.
+        com.apple.developer.networking.multicast: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: eu.vaultsync.app


### PR DESCRIPTION
  Apple approved `com.apple.developer.networking.multicast` for this App ID — this enables
  it in the app's entitlements.

  **Why:** Syncthing's local peer discovery uses multicast. Without the entitlement iOS
  blocks it, so same-Wi-Fi peers are only found via global discovery + direct dial
  (slower, relay-prone). With it, local discovery works directly — completing the
  local-network work from 1.7.0.

  **Changes:**
  - `ios/project.yml` → generated `entitlements.properties` (source of truth) +
  regenerated `ios/VaultSync/VaultSync.entitlements`.
  - `CHANGELOG.md` → 1.7.1 "Changed" note.

  No code or test changes.

  **Before the next App Store archive:** the Distribution provisioning profile must
  include the new entitlement — Xcode automatic signing refreshes it on archive; with
  manual signing, regenerate and re-download the Distribution profile in the Developer
  portal first.