### PR TITLE
feat(ios): let the user pick or create the target vault when accepting a share (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to VaultSync are documented here.
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **A vault you remove now stays removed** ([#52](https://github.com/psimaker/vaultsync/issues/52)) — as long as another device still shares a removed folder, its share request reappears within moments, and VaultSync used to accept it again automatically — silently undoing the removal. A share whose vault you removed now stays under "Pending Shares" until you accept it yourself. The recovery steps for overlapping vaults are now explicit for the same reason: remove the affected vault, then accept the returning share — nothing is re-added behind your back.
+
+### Added
+
+- **Choose where a share syncs** ([#52](https://github.com/psimaker/vaultsync/issues/52)) — a new "Choose Vault…" option on every pending share lets you pick an existing *empty* vault (create the vault in Obsidian first, then link the share to it) or create a folder with a name of your choice, instead of the automatic folder named after the share — share names like "Obsidian-Vault-Life" no longer dictate your local vault name. VaultSync remembers the choice: remove the vault and accept the share again, and it returns to the folder you picked — never silently to the automatic one. Locations that overlap another vault's folder are refused at every layer, and only empty vaults can be linked, so two vaults can never mix (the #45 guarantees are untouched). Localized in English, German, Spanish, and Simplified Chinese.
+
 ## [1.7.2] — 2026-07-07
 
 ### Fixed

--- a/docs/decisions/006-no-auto-reaccept-manual-share-targets.md
+++ b/docs/decisions/006-no-auto-reaccept-manual-share-targets.md
@@ -1,0 +1,11 @@
+# 006 — Removed vaults are never auto-re-accepted; manual share targets persist
+
+**Context:** While a peer still shares a folder, its offer reappears moments after local removal, and the auto-accept loop pulled it straight back in — "Remove Vault" was silently undone, and the #52 manual target picker was unreachable because a share never stayed pending long enough to act on.
+
+**Decision:** `removeFolder` records the folder ID as user-removed; auto-accept skips recorded shares (they stay visible under Pending Shares until explicitly accepted, which lifts the record). A manually picked target (#52) is stored per folder ID, deliberately survives removal, and is honored by every later accept; an override that became unsafe is refused with guidance. Only empty folders (nothing but `.obsidian`) are eligible as existing targets.
+
+**Why:** This is [002](002-manual-recovery-doctrine.md) applied to accept: re-accepting user data is never automatic once the user expressed intent by removing the folder — recovery and re-adding stay explicit user actions. Silently falling back to the share-label default when the chosen target is unsafe would split one vault's content across two directories.
+
+**Rejected alternatives:** A global "ask before accepting shares" toggle — changes the default for every share and still cannot stop the instant re-accept after removal. Pruning the user-removed set against currently pending offers — would drop the record before the offer reappears (it can take a reconnect), re-enabling the zombie re-accept. Silent fallback to the label default on an unsafe override — hides a data-placement decision from the user.
+
+**Links:** issue #52, issue #45 (follow-up), decision 002.

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -84,6 +84,12 @@ final class SyncthingManager {
     private(set) var conflictFiles: [String: [ConflictInfo]] = [:]
     private(set) var pendingFolders: [PendingFolderInfo] = []
     private(set) var ignoredPendingFolderIDs: Set<String> = []
+    /// Folder IDs the user removed on this iPhone. While a peer still shares
+    /// such a folder, its offer reappears as pending within moments — and
+    /// auto-accepting it would silently undo the removal. Re-adding is an
+    /// explicit user decision (doctrine 002 / #52). Deliberately never pruned:
+    /// the set stays tiny and an entry is only lifted by an explicit accept.
+    private(set) var userRemovedFolderIDs: Set<String> = []
     private(set) var hasSeenPendingFolderOffer = false
     private(set) var lastSyncTime: Date?
     private(set) var lastSyncTimeByFolder: [String: Date] = [:]
@@ -107,6 +113,7 @@ final class SyncthingManager {
     private var backgroundSyncObserver: NSObjectProtocol?
     private let syncHistoryStore: SyncHistoryStore
     private static let ignoredPendingFoldersDefaultsKey = "syncthing.ignoredPendingFolderIDs"
+    private static let userRemovedFoldersDefaultsKey = "syncthing.userRemovedFolderIDs"
     private static let hasSeenPendingOfferDefaultsKey = "syncthing.hasSeenPendingFolderOffer"
     private static let staleSyncThreshold: TimeInterval = 12 * 60 * 60
     private static let maxSyncActivityItems = 120
@@ -153,6 +160,7 @@ final class SyncthingManager {
         self.syncHistoryStore = syncHistoryStore
 
         ignoredPendingFolderIDs = Self.loadIgnoredPendingFolderIDs()
+        userRemovedFolderIDs = Self.loadUserRemovedFolderIDs()
         hasSeenPendingFolderOffer = UserDefaults.standard.bool(forKey: Self.hasSeenPendingOfferDefaultsKey)
 
         let history = syncHistoryStore.load()
@@ -309,6 +317,23 @@ final class SyncthingManager {
         pendingFolders.filter { !ignoredPendingFolderIDs.contains($0.id) }
     }
 
+    /// Pending shares the automatic accept loop may act on: actionable (not
+    /// ignored) and not previously removed by the user. A share whose folder
+    /// the user removed stays visible as a pending row but is only ever
+    /// accepted by an explicit tap (doctrine 002 / #52) — auto-accepting it
+    /// would undo the removal moments later while a peer still shares it.
+    var autoAcceptEligiblePendingFolders: [PendingFolderInfo] {
+        Self.autoAcceptEligible(actionable: actionablePendingFolders, userRemoved: userRemovedFolderIDs)
+    }
+
+    /// Pure core of the auto-accept eligibility rule (unit-testable).
+    nonisolated static func autoAcceptEligible(
+        actionable: [PendingFolderInfo],
+        userRemoved: Set<String>
+    ) -> [PendingFolderInfo] {
+        actionable.filter { !userRemoved.contains($0.id) }
+    }
+
     var ignoredPendingFolders: [PendingFolderInfo] {
         pendingFolders.filter { ignoredPendingFolderIDs.contains($0.id) }
     }
@@ -445,7 +470,7 @@ final class SyncthingManager {
                     kind: .pathCollision,
                     title: L10n.tr("Two Vaults Are Sharing One Folder"),
                     message: L10n.tr("Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage."),
-                    remediation: L10n.tr("Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first."),
+                    remediation: L10n.tr("Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first."),
                     severity: .critical,
                     count: affectedCount,
                     folderID: collisionGroups.flatMap { $0 }.min(),
@@ -470,7 +495,7 @@ final class SyncthingManager {
                     kind: .nestedFolders,
                     title: L10n.tr("One Vault Is Nested Inside Another"),
                     message: L10n.tr("A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing."),
-                    remediation: L10n.tr("Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices."),
+                    remediation: L10n.tr("Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices."),
                     severity: .critical,
                     count: nestedIDs.count,
                     folderID: nestedIDs.min(),
@@ -737,8 +762,17 @@ final class SyncthingManager {
             FolderPathReconciler.removeRel(forFolder: id)
             // Forget any #45 auto-pause record so a future folder reusing this
             // ID can be paused again if it collides (removing a colliding vault
-            // is the sanctioned recovery, after which it is re-added unpaused).
+            // is the sanctioned recovery; accepting the returning share re-adds
+            // it unpaused into its own folder).
             PathCollisionGuard.clearAutoPaused(id)
+            // Never auto-re-accept a share the user just removed: while a peer
+            // still shares the folder, the offer reappears within moments, and
+            // silently pulling it back in would undo the removal (doctrine
+            // 002 / #52). The share stays visible under Pending Shares until
+            // the user explicitly accepts it — which then honours a manually
+            // chosen target.
+            userRemovedFolderIDs.insert(id)
+            persistUserRemovedFolderIDs()
         }
         return result
     }
@@ -825,6 +859,12 @@ final class SyncthingManager {
     func acceptPendingFolder(folderID: String, label: String, path: String) -> String? {
         let result = SyncBridgeService.acceptPendingFolder(folderID: folderID, label: label, path: path)
         if result == nil {
+            // An explicit accept supersedes an earlier removal — lift the
+            // auto-accept suppression for this folder ID (#52).
+            if userRemovedFolderIDs.contains(folderID) {
+                userRemovedFolderIDs.remove(folderID)
+                persistUserRemovedFolderIDs()
+            }
             refreshFolders()
             refreshPendingFolders()
             // Trigger a rescan after a short delay to kick-start initial sync.
@@ -1787,6 +1827,17 @@ final class SyncthingManager {
 
     private func persistIgnoredPendingFolderIDs() {
         UserDefaults.standard.set(Array(ignoredPendingFolderIDs).sorted(), forKey: Self.ignoredPendingFoldersDefaultsKey)
+    }
+
+    private func persistUserRemovedFolderIDs() {
+        UserDefaults.standard.set(Array(userRemovedFolderIDs).sorted(), forKey: Self.userRemovedFoldersDefaultsKey)
+    }
+
+    private static func loadUserRemovedFolderIDs() -> Set<String> {
+        guard let values = UserDefaults.standard.array(forKey: userRemovedFoldersDefaultsKey) as? [String] else {
+            return []
+        }
+        return Set(values)
     }
 
     private static func loadIgnoredPendingFolderIDs() -> Set<String> {

--- a/ios/VaultSync/Services/VaultManager.swift
+++ b/ios/VaultSync/Services/VaultManager.swift
@@ -213,27 +213,42 @@ final class VaultManager {
             FolderPathReconciler.canonical($0.path).lowercased()
         })
 
-        guard let path = Self.resolveSharePath(
+        // A manually chosen target (#52) wins over the label-derived mapping.
+        // The record survives folder removal, so remove + re-accept lands the
+        // share back where the user put it, never silently at the label default.
+        let manualTarget = ManualShareTargetStore.target(forFolder: folder.id)
+
+        let decision = Self.resolveAcceptPath(
+            manualTarget: manualTarget,
             rawRoot: basePath,
             baseIsVault: baseIsVault,
             nameMatchesBase: nameMatchesBase,
             folderName: folderName,
             occupiedCanonLower: occupied,
             canonicalize: FolderPathReconciler.canonical
-        ) else {
-            // The selected root is itself (or lies inside) another folder's
-            // synced directory — accepting would nest this vault inside an
-            // existing one and mix their contents (#45 follow-up). Refuse with
-            // guidance; the share stays pending and auto-accept retries after
-            // the user re-selects the container folder.
-            logger.error("Refusing share '\(folderName, privacy: .private)' (\(folder.id)): no overlap-free location under the Obsidian root (baseIsVault=\(baseIsVault), occupied=\(occupied.count))")
-            return L10n.tr("This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other.")
+        )
+
+        let path: String
+        switch decision {
+        case .refused(let message):
+            // Either the selected root is itself (or lies inside) another
+            // folder's synced directory (#45 follow-up), or the stored manual
+            // target has become unsafe. Refuse with guidance; the share stays
+            // pending until the user acts.
+            logger.error("Refusing share '\(folderName, privacy: .private)' (\(folder.id)): no safe location (manual=\(manualTarget != nil), baseIsVault=\(baseIsVault), occupied=\(occupied.count))")
+            return message
+        case .path(let resolved):
+            path = resolved
         }
-        logger.info("Accepting share '\(folderName, privacy: .private)' (\(folder.id)) → path: \(path, privacy: .private) (baseIsVault=\(baseIsVault), nameMatchesBase=\(nameMatchesBase), occupied=\(occupied.count))")
+
+        // The local vault keeps the user's chosen name when one exists; the
+        // share label on the offering devices is untouched either way (#52).
+        let label = manualTarget ?? folderName
+        logger.info("Accepting share '\(folderName, privacy: .private)' (\(folder.id)) → path: \(path, privacy: .private) (manual=\(manualTarget != nil), baseIsVault=\(baseIsVault), nameMatchesBase=\(nameMatchesBase), occupied=\(occupied.count))")
 
         if let err = syncthingManager.acceptPendingFolder(
             folderID: folder.id,
-            label: folderName,
+            label: label,
             path: path
         ) {
             return err
@@ -292,16 +307,8 @@ final class VaultManager {
         occupiedCanonLower: Set<String>,
         canonicalize: (String) -> String
     ) -> String? {
-        func canonLower(_ path: String) -> String {
-            canonicalize(path).lowercased()
-        }
-        // Whether the candidate is one of the occupied directories, lies inside
-        // one, or holds one — any of these mixes two folders' contents.
         func overlapsOccupied(_ candidate: String) -> Bool {
-            let c = canonLower(candidate)
-            return occupiedCanonLower.contains { occ in
-                occ == c || occ.hasPrefix(c + "/") || c.hasPrefix(occ + "/")
-            }
+            overlaps(candidate, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize)
         }
 
         // Collapse into the root only while nothing overlaps it.
@@ -312,10 +319,7 @@ final class VaultManager {
         // Once the root is — or lies inside — an occupied directory, every
         // subdirectory would nest this share inside an existing folder's synced
         // tree. There is no safe location under this root at all.
-        let rootCanon = canonLower(rawRoot)
-        if occupiedCanonLower.contains(where: { occ in
-            occ == rootCanon || rootCanon.hasPrefix(occ + "/")
-        }) {
+        if rootIsCompromised(rawRoot, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize) {
             return nil
         }
 
@@ -338,8 +342,237 @@ final class VaultManager {
         }
     }
 
+    /// Whether the candidate is one of the occupied directories, lies inside
+    /// one, or holds one — any of these mixes two folders' contents (#45).
+    /// Shared by the label-derived mapping (`resolveSharePath`) and the manual
+    /// target validation (#52) so the two accept paths can never disagree on
+    /// what counts as an overlap. Case-insensitive: case-folding APFS.
+    nonisolated private static func overlaps(
+        _ candidate: String,
+        occupiedCanonLower: Set<String>,
+        canonicalize: (String) -> String
+    ) -> Bool {
+        let c = canonicalize(candidate).lowercased()
+        return occupiedCanonLower.contains { occ in
+            occ == c || occ.hasPrefix(c + "/") || c.hasPrefix(occ + "/")
+        }
+    }
+
+    /// Whether the root itself is — or lies inside — an occupied directory.
+    /// Then every subdirectory would nest inside an existing folder's synced
+    /// tree, so no safe location exists under this root at all (#45 follow-up).
+    nonisolated private static func rootIsCompromised(
+        _ rawRoot: String,
+        occupiedCanonLower: Set<String>,
+        canonicalize: (String) -> String
+    ) -> Bool {
+        let rootCanon = canonicalize(rawRoot).lowercased()
+        return occupiedCanonLower.contains { occ in
+            occ == rootCanon || rootCanon.hasPrefix(occ + "/")
+        }
+    }
+
+    // MARK: - Manual Share Target (#52)
+
+    /// Decide where a pending share syncs: a manually chosen target recorded
+    /// earlier (#52) wins over the label-derived mapping. An override that has
+    /// become unsafe is refused with guidance — never silently replaced by the
+    /// share-label default, because the user chose that location deliberately
+    /// and accepting somewhere else would split the vault across two
+    /// directories. The override path is NOT required to be empty: after
+    /// remove + re-accept it legitimately holds this same share's earlier
+    /// content (exactly like the label-default path on a plain re-accept).
+    nonisolated static func resolveAcceptPath(
+        manualTarget: String?,
+        rawRoot: String,
+        baseIsVault: Bool,
+        nameMatchesBase: Bool,
+        folderName: String,
+        occupiedCanonLower: Set<String>,
+        canonicalize: (String) -> String
+    ) -> ShareTargetDecision {
+        if let target = manualTarget {
+            let candidate = (rawRoot as NSString).appendingPathComponent(target)
+            if rootIsCompromised(rawRoot, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize)
+                || overlaps(candidate, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize) {
+                return .refused(message: L10n.fmt(
+                    "This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again.",
+                    target
+                ))
+            }
+            return .path(candidate)
+        }
+
+        guard let path = resolveSharePath(
+            rawRoot: rawRoot,
+            baseIsVault: baseIsVault,
+            nameMatchesBase: nameMatchesBase,
+            folderName: folderName,
+            occupiedCanonLower: occupiedCanonLower,
+            canonicalize: canonicalize
+        ) else {
+            return .refused(message: L10n.tr("This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other."))
+        }
+        return .path(path)
+    }
+
+    /// Validate a manually chosen share target (issue #52): `name` — a picked
+    /// existing vault or a new-folder name — becomes `root/<sanitized name>`.
+    /// Refusal messages name the folder, the reason, and the user's next step.
+    /// Pure: the caller supplies the target's directory listing
+    /// (`targetEntries`; nil when the directory does not exist yet, hidden
+    /// entries included otherwise) so every rule is unit-testable without the
+    /// filesystem.
+    ///
+    /// Only *empty* vaults are eligible as existing targets: linking a share
+    /// to a folder that already holds content would merge two content sets,
+    /// which needs its own safety design (out of scope for #52).
+    nonisolated static func validateManualTarget(
+        rawRoot: String,
+        name: String,
+        occupiedCanonLower: Set<String>,
+        targetEntries: [String]?,
+        canonicalize: (String) -> String
+    ) -> ShareTargetDecision {
+        let folderName = sanitizeDirectoryName(name)
+        guard !folderName.isEmpty else {
+            return .refused(message: L10n.tr("Enter a folder name."))
+        }
+        if rootIsCompromised(rawRoot, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize) {
+            return .refused(message: L10n.tr("This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other."))
+        }
+        let candidate = (rawRoot as NSString).appendingPathComponent(folderName)
+        if overlaps(candidate, occupiedCanonLower: occupiedCanonLower, canonicalize: canonicalize) {
+            return .refused(message: L10n.fmt(
+                "The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first.",
+                folderName
+            ))
+        }
+        if let entries = targetEntries, !isEmptyVaultListing(entries) {
+            return .refused(message: L10n.fmt(
+                "The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name.",
+                folderName
+            ))
+        }
+        return .path(candidate)
+    }
+
+    /// True when a directory listing qualifies as an *empty vault*: nothing
+    /// inside except (at most) Obsidian's `.obsidian` configuration folder.
+    /// Anything else — notes, a `.stfolder` sync marker, hidden leftovers —
+    /// disqualifies the directory, because linking a share there would merge
+    /// two content sets. Case-insensitive: case-folding APFS.
+    nonisolated static func isEmptyVaultListing(_ entries: [String]) -> Bool {
+        entries.allSatisfy { $0.compare(".obsidian", options: .caseInsensitive) == .orderedSame }
+    }
+
+    /// Accept a pending share into a target the user picked (issue #52): an
+    /// existing empty vault under the Obsidian directory, or a new folder with
+    /// a custom name. Records the choice so any later re-accept (after the
+    /// user removes the vault) returns to this location instead of the
+    /// share-label default. Returns nil on success, error message on failure.
+    func acceptPendingShare(
+        folder: SyncthingManager.PendingFolderInfo,
+        intoTargetNamed targetName: String,
+        syncthingManager: SyncthingManager
+    ) -> String? {
+        guard let basePath = obsidianBasePath,
+              let baseURL = obsidianDirectoryURL else {
+            return L10n.tr("Obsidian directory not accessible.")
+        }
+
+        let occupied = Set(syncthingManager.folders.map {
+            FolderPathReconciler.canonical($0.path).lowercased()
+        })
+
+        // Full listing, hidden entries included: a `.stfolder` marker or a
+        // hidden leftover must disqualify a target, so an enumeration that
+        // skips hidden files would hide exactly what matters.
+        let sanitized = Self.sanitizeDirectoryName(targetName)
+        let targetURL = baseURL.appendingPathComponent(sanitized, isDirectory: true)
+        let entries = try? FileManager.default.contentsOfDirectory(atPath: targetURL.path)
+
+        let decision = Self.validateManualTarget(
+            rawRoot: basePath,
+            name: targetName,
+            occupiedCanonLower: occupied,
+            targetEntries: entries,
+            canonicalize: FolderPathReconciler.canonical
+        )
+
+        switch decision {
+        case .refused(let message):
+            logger.error("Refusing manual target for share (\(folder.id)): \(message, privacy: .private)")
+            return message
+        case .path(let path):
+            if let err = syncthingManager.acceptPendingFolder(
+                folderID: folder.id,
+                label: sanitized,
+                path: path
+            ) {
+                return err
+            }
+            // Only a successful accept records the choice — a failed one must
+            // not pin future auto-accepts to a target that never materialized.
+            ManualShareTargetStore.setTarget(sanitized, forFolder: folder.id)
+            if let rel = FolderPathReconciler.relativeIfUnder(
+                FolderPathReconciler.canonical(path),
+                root: FolderPathReconciler.canonical(basePath)
+            ) {
+                FolderPathReconciler.setRel(rel, forFolder: folder.id)
+            }
+            scanForVaults()
+            logger.info("Accepted pending share into manual target (\(folder.id)) → \(path, privacy: .private)")
+            return nil
+        }
+    }
+
+    /// Names of existing subdirectories under the Obsidian root that qualify
+    /// as manual share targets (#52): empty vaults (nothing inside except at
+    /// most `.obsidian`) whose path does not overlap any configured folder's.
+    /// The picker lists these; everything else is reachable only as a newly
+    /// created folder.
+    func eligibleShareTargets(syncthingManager: SyncthingManager) -> [String] {
+        guard let baseURL = obsidianDirectoryURL,
+              let basePath = obsidianBasePath else {
+            return []
+        }
+        let occupied = Set(syncthingManager.folders.map {
+            FolderPathReconciler.canonical($0.path).lowercased()
+        })
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: baseURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+        return contents.compactMap { itemURL -> String? in
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: itemURL.path, isDirectory: &isDir), isDir.boolValue else {
+                return nil
+            }
+            let name = itemURL.lastPathComponent
+            // A name that changes under sanitization would be validated (and
+            // created) as a different directory than the one listed — skip it.
+            guard Self.sanitizeDirectoryName(name) == name else { return nil }
+            guard let entries = try? fm.contentsOfDirectory(atPath: itemURL.path) else { return nil }
+            guard case .path = Self.validateManualTarget(
+                rawRoot: basePath,
+                name: name,
+                occupiedCanonLower: occupied,
+                targetEntries: entries,
+                canonicalize: FolderPathReconciler.canonical
+            ) else {
+                return nil
+            }
+            return name
+        }.sorted()
+    }
+
     /// Replace characters that are invalid in iOS directory names.
-    private static func sanitizeDirectoryName(_ name: String) -> String {
+    nonisolated static func sanitizeDirectoryName(_ name: String) -> String {
         let invalid = CharacterSet(charactersIn: "/:\0")
         return name.components(separatedBy: invalid)
             .joined(separator: "-")
@@ -404,5 +637,46 @@ final class VaultManager {
             remediation: L10n.tr("Open the folder picker again and select your Obsidian directory."),
             technicalDetails: reason
         )
+    }
+}
+
+/// Outcome of deciding where a share may sync: a safe absolute path, or a
+/// refusal whose message names the folder, the reason, and the user's next
+/// step. Top-level value type (not nested in the `@MainActor` class) so the
+/// pure decision cores stay callable and comparable from any isolation.
+enum ShareTargetDecision: Equatable, Sendable {
+    case path(String)
+    case refused(message: String)
+}
+
+/// Sidecar: the local folder name the user manually picked for a share
+/// (issue #52), keyed by Syncthing folder ID. Deliberately SURVIVES folder
+/// removal — removing a vault and accepting the returning share must land it
+/// back in the chosen location, never silently in the share-label default —
+/// so `SyncthingManager.removeFolder` must not clear it (unlike the
+/// reconciler's rel sidecar, which tracks where a *configured* folder lives).
+/// Entries are never pruned: the map stays tiny (one name per manually placed
+/// share, ever) and a stale entry is harmless — every accept re-validates it
+/// against the overlap guards. Same serialized-queue UserDefaults pattern as
+/// `FolderPathReconciler`.
+enum ManualShareTargetStore {
+    private static let storeKey = "vaultsync.manualShareTargets"
+    private static let queue = DispatchQueue(label: "eu.vaultsync.manualsharetargets.sidecar")
+
+    static func target(forFolder folderID: String) -> String? {
+        queue.sync {
+            (UserDefaults.standard.dictionary(forKey: storeKey) as? [String: String])?[folderID]
+        }
+    }
+
+    /// Record the chosen folder name after a successful manual accept.
+    /// Atomic read-modify-write.
+    static func setTarget(_ name: String, forFolder folderID: String) {
+        queue.sync {
+            var map = UserDefaults.standard.dictionary(forKey: storeKey) as? [String: String] ?? [:]
+            guard map[folderID] != name else { return }
+            map[folderID] = name
+            UserDefaults.standard.set(map, forKey: storeKey)
+        }
     }
 }

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State private var showInfoAlert = false
     @State private var pendingShareFailures: [String: SyncUserError] = [:]
     @State private var pendingShareInFlight: Set<String> = []
+    @State private var shareTargetPickerFolder: SyncthingManager.PendingFolderInfo?
     @State private var pendingFilterSheetFolder: SyncthingManager.FolderInfo?
     @State private var vaultPendingRemoval: VaultRemovalTarget?
     @State private var showRelayUpsellCard = false
@@ -134,6 +135,16 @@ struct ContentView: View {
             Button(L10n.tr("Cancel"), role: .cancel) { vaultPendingRemoval = nil }
         } message: { target in
             Text(L10n.fmt("“%@” will stop syncing on this iPhone. Files already on your other devices are not deleted.", target.label))
+        }
+        .sheet(item: $shareTargetPickerFolder) { folder in
+            ShareTargetPickerView(
+                shareLabel: folder.label.isEmpty ? folder.id : folder.label,
+                defaultName: VaultManager.sanitizeDirectoryName(folder.label.isEmpty ? folder.id : folder.label),
+                eligibleVaults: vaultManager.eligibleShareTargets(syncthingManager: syncthingManager),
+                onConfirm: { targetName in
+                    manualAcceptPendingShare(folder: folder, targetName: targetName)
+                }
+            )
         }
         .onChange(of: syncthingManager.pendingFolders, initial: true) { _, pending in
             autoAcceptPendingShares(pending)
@@ -277,10 +288,36 @@ struct ContentView: View {
 
         guard vaultManager.isAccessible else { return }
 
-        for folder in syncthingManager.actionablePendingFolders where pendingShareFailures[folder.id] == nil {
+        // Auto-accept skips shares whose folder the user removed on this
+        // iPhone (doctrine 002 / #52) — those stay visible as pending rows
+        // until the user accepts them explicitly.
+        for folder in syncthingManager.autoAcceptEligiblePendingFolders where pendingShareFailures[folder.id] == nil {
             guard !pendingShareInFlight.contains(folder.id) else { continue }
             performPendingShareAccept(folder: folder, source: .automatic)
         }
+    }
+
+    /// Accept a share into a user-picked target (#52). Returns the error to
+    /// show inline in the picker sheet, or nil on success (the sheet then
+    /// dismisses itself).
+    private func manualAcceptPendingShare(
+        folder: SyncthingManager.PendingFolderInfo,
+        targetName: String
+    ) -> String? {
+        pendingShareInFlight.insert(folder.id)
+        let err = vaultManager.acceptPendingShare(
+            folder: folder,
+            intoTargetNamed: targetName,
+            syncthingManager: syncthingManager
+        )
+        pendingShareInFlight.remove(folder.id)
+
+        if let err {
+            return mappedError(err, fallbackTitle: L10n.tr("Could Not Accept Share")).userVisibleDescription
+        }
+        pendingShareFailures.removeValue(forKey: folder.id)
+        syncthingManager.unignorePendingFolder(id: folder.id)
+        return nil
     }
 
     private enum PendingShareAcceptSource {
@@ -690,6 +727,9 @@ struct ContentView: View {
                     },
                     onRestoreIgnored: { folder in
                         syncthingManager.unignorePendingFolder(id: folder.id)
+                    },
+                    onChooseTarget: { folder in
+                        shareTargetPickerFolder = folder
                     },
                     onReconnectObsidian: {
                         showObsidianPicker = true

--- a/ios/VaultSync/Views/PendingSharesView.swift
+++ b/ios/VaultSync/Views/PendingSharesView.swift
@@ -10,6 +10,7 @@ struct PendingSharesView: View {
     var onRetry: (SyncthingManager.PendingFolderInfo) -> Void
     var onIgnore: (SyncthingManager.PendingFolderInfo) -> Void
     var onRestoreIgnored: (SyncthingManager.PendingFolderInfo) -> Void
+    var onChooseTarget: (SyncthingManager.PendingFolderInfo) -> Void
     var onReconnectObsidian: () -> Void
 
     var body: some View {
@@ -47,11 +48,22 @@ struct PendingSharesView: View {
                                         .foregroundStyle(.secondary)
                                 }
                                 Spacer()
-                                Button("Restore Share") {
-                                    onRestoreIgnored(folder)
+                                // Restoring hands the share back to auto-accept;
+                                // "Choose Vault…" accepts it directly into a
+                                // picked target instead (#52).
+                                VStack(alignment: .trailing, spacing: VaultSpacing.xs) {
+                                    Button("Restore Share") {
+                                        onRestoreIgnored(folder)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.regular)
+                                    Button("Choose Vault…") {
+                                        onChooseTarget(folder)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.regular)
+                                    .disabled(!obsidianAccessible)
                                 }
-                                .buttonStyle(.bordered)
-                                .controlSize(.regular)
                             }
                         }
                     }
@@ -130,6 +142,16 @@ struct PendingSharesView: View {
                 }
                 .buttonStyle(.bordered)
                 .disabled(inFlightFolderIDs.contains(folder.id))
+            }
+
+            // The per-share manual path (#52): pick an existing empty vault or
+            // create a custom-named folder instead of the share-label default.
+            if !inFlightFolderIDs.contains(folder.id) {
+                Button("Choose Vault…") {
+                    onChooseTarget(folder)
+                }
+                .buttonStyle(.bordered)
+                .disabled(!obsidianAccessible)
             }
         }
         .padding(VaultSpacing.m)

--- a/ios/VaultSync/Views/ShareTargetPickerView.swift
+++ b/ios/VaultSync/Views/ShareTargetPickerView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+/// Sheet for issue #52: choose where a pending share syncs on this iPhone —
+/// an existing *empty* vault under the Obsidian directory, or a new folder
+/// with a custom name (decoupling the local vault name from the share label,
+/// which stays unchanged on the offering devices). Auto-accept remains the
+/// default; this sheet is the per-share manual path.
+///
+/// The picker itself carries no safety burden beyond honest presentation:
+/// every confirmed choice is re-validated in `VaultManager` (overlap +
+/// emptiness) and by the Go engine's overlap hard floor.
+struct ShareTargetPickerView: View {
+    let shareLabel: String
+    /// The folder name auto-accept would use — prefills the new-folder field.
+    let defaultName: String
+    /// Existing empty vaults eligible as targets (`eligibleShareTargets`).
+    let eligibleVaults: [String]
+    /// Attempt the accept; returns a user-facing error, or nil on success.
+    var onConfirm: (String) -> String?
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedVault: String?
+    @State private var newFolderName: String
+    @State private var errorMessage: String?
+
+    init(
+        shareLabel: String,
+        defaultName: String,
+        eligibleVaults: [String],
+        onConfirm: @escaping (String) -> String?
+    ) {
+        self.shareLabel = shareLabel
+        self.defaultName = defaultName
+        self.eligibleVaults = eligibleVaults
+        self.onConfirm = onConfirm
+        _newFolderName = State(initialValue: defaultName)
+    }
+
+    /// A picked existing vault wins; otherwise the (trimmed) new-folder name.
+    private var effectiveTarget: String {
+        selectedVault ?? newFolderName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text(L10n.fmt("Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices.", shareLabel))
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section {
+                    if eligibleVaults.isEmpty {
+                        Text(L10n.tr("No empty vaults found. Create the vault in Obsidian first, or use a new folder below."))
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        ForEach(eligibleVaults, id: \.self) { vault in
+                            Button {
+                                selectedVault = selectedVault == vault ? nil : vault
+                            } label: {
+                                HStack {
+                                    Label(vault, systemImage: "folder")
+                                    Spacer()
+                                    if selectedVault == vault {
+                                        Image(systemName: "checkmark")
+                                            .foregroundStyle(Color.vaultAccent)
+                                            .accessibilityHidden(true)
+                                    }
+                                }
+                            }
+                            .tint(.primary)
+                            .accessibilityAddTraits(selectedVault == vault ? .isSelected : [])
+                        }
+                    }
+                } header: {
+                    Text(L10n.tr("Existing Empty Vaults"))
+                } footer: {
+                    Text(L10n.tr("Only vaults without any notes yet can be linked to a share."))
+                }
+
+                Section {
+                    TextField(L10n.tr("Folder name"), text: $newFolderName)
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+                        .onChange(of: newFolderName) { _, _ in
+                            // Typing a name is choosing the new-folder option.
+                            selectedVault = nil
+                        }
+                } header: {
+                    Text(L10n.tr("New Folder"))
+                } footer: {
+                    Text(L10n.tr("Creates a folder with this name in your Obsidian directory and syncs the share into it."))
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.callout)
+                            .foregroundStyle(Color.statusError)
+                    }
+                }
+            }
+            .navigationTitle(L10n.tr("Choose Vault"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(L10n.tr("Cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(L10n.tr("Link Share")) {
+                        if let err = onConfirm(effectiveTarget) {
+                            errorMessage = err
+                            return
+                        }
+                        dismiss()
+                    }
+                    .bold()
+                    .disabled(effectiveTarget.isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -29,6 +29,9 @@
 "Check your connection and retry." = "Prüfe deine Verbindung und versuche es erneut.";
 "Check your internet connection and try the relay health check again on the Relay tab." = "Prüfe deine Internetverbindung und führe den Relay-Health-Check im Relay-Tab erneut aus.";
 "Check your subscription status on the Relay tab and retry. If this persists, restart VaultSync." = "Prüfe deinen Abostatus im Relay-Tab und versuche es erneut. Wenn das Problem bleibt, starte VaultSync neu.";
+"Choose Vault" = "Vault wählen";
+"Choose Vault…" = "Vault wählen…";
+"Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices." = "Wähle, wohin „%@“ auf diesem iPhone synchronisiert wird. Auf deinen anderen Geräten behält die Freigabe ihren Namen.";
 "Cloud Relay" = "Cloud Relay";
 "Cloud Relay active" = "Cloud Relay aktiv";
 "Cloud Relay is not currently subscribed. Push-triggered wake-ups are disabled until the subscription is active." = "Cloud Relay ist derzeit nicht abonniert. Push-ausgelöste Weck-Signale sind deaktiviert, bis das Abo aktiv ist.";
@@ -62,6 +65,7 @@
 "Could not read files.\n\n%@\n%@" = "Dateien konnten nicht gelesen werden.\n\n%@\n%@";
 "Could not read original file.\n\n%@" = "Originaldatei konnte nicht gelesen werden.\n\n%@";
 "Create a vault in Obsidian first. VaultSync will detect it automatically." = "Erstelle zuerst einen Vault in Obsidian. VaultSync erkennt ihn automatisch.";
+"Creates a folder with this name in your Obsidian directory and syncs the share into it." = "Erstellt einen Ordner mit diesem Namen in deinem Obsidian-Verzeichnis und synchronisiert die Freigabe dorthin.";
 "Device" = "Gerät";
 "Device ID" = "Geräte-ID";
 "%d of %d devices connected" = "%d von %d Geräten verbunden";
@@ -72,13 +76,16 @@
 "Done" = "Fertig";
 "Empty line" = "Leere Zeile";
 "Enable notifications for VaultSync in iOS Settings → Notifications → VaultSync, then restart the app." = "Aktiviere Mitteilungen für VaultSync unter iOS Einstellungen → Mitteilungen → VaultSync und starte die App dann neu.";
+"Enter a folder name." = "Gib einen Ordnernamen ein.";
 "Error" = "Fehler";
+"Existing Empty Vaults" = "Bestehende leere Vaults";
 "Failed" = "Fehlgeschlagen";
 "Failed to save access permission: %@" = "Zugriffsberechtigung konnte nicht gespeichert werden: %@";
 "Failed to sync file in %@" = "Datei in %@ konnte nicht synchronisiert werden";
 "File Read Failed" = "Datei konnte nicht gelesen werden";
 "File synced in %@" = "Datei in %@ synchronisiert";
 "Files are being synchronized with peers." = "Dateien werden mit Peers synchronisiert.";
+"Folder name" = "Ordnername";
 "Folder Not Configured" = "Ordner nicht konfiguriert";
 "Folder Path Missing" = "Ordnerpfad fehlt";
 "Folder Permission Error" = "Ordnerberechtigungsfehler";
@@ -118,6 +125,7 @@
 "Last sync: %@" = "Letzter Sync: %@";
 "Latency" = "Latenz";
 "Learn how to fix" = "Lösung anzeigen";
+"Link Share" = "Freigabe verknüpfen";
 "Loading…" = "Wird geladen…";
 "Local Files" = "Lokale Dateien";
 "Log" = "Protokoll";
@@ -128,6 +136,8 @@
 "Needs Attention" = "Aktion nötig";
 "Network Error" = "Netzwerkfehler";
 "Never" = "Nie";
+"New Folder" = "Neuer Ordner";
+"No empty vaults found. Create the vault in Obsidian first, or use a new folder below." = "Keine leeren Vaults gefunden. Erstelle den Vault zuerst in Obsidian oder verwende unten einen neuen Ordner.";
 "No Syncthing peers available yet." = "Noch keine Syncthing-Peers verfügbar.";
 "No action needed." = "Keine Aktion erforderlich.";
 "No active pending shares" = "Keine aktiven ausstehenden Freigaben";
@@ -152,6 +162,7 @@
 "Obsidian directory not accessible." = "Auf das Obsidian-Verzeichnis kann nicht zugegriffen werden.";
 "Obsidian folder not connected" = "Obsidian-Ordner nicht verbunden";
 "Offline" = "Offline";
+"Only vaults without any notes yet can be linked to a share." = "Nur Vaults, die noch keine Notizen enthalten, können mit einer Freigabe verknüpft werden.";
 "Open Settings" = "Einstellungen öffnen";
 "Open the Relay tab" = "Relay-Tab öffnen";
 "Open VaultSync" = "VaultSync öffnen";
@@ -233,6 +244,9 @@
 "Purchase Failed" = "Kauf fehlgeschlagen";
 "Rescan All Vaults" = "Alle Vaults erneut scannen";
 "Sync Conflicts" = "Sync-Konflikte";
+"The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name." = "Der Ordner „%@“ enthält bereits Dateien. Eine Freigabe kann nur mit einem leeren Vault verknüpft werden – wähle einen leeren Vault oder gib einen neuen Ordnernamen ein.";
+"The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first." = "Der Zielordner „%@“ wird bereits von einem anderen Vault synchronisiert – derselbe Ordner oder einer darüber oder darin. Wähle einen anderen Ordner oder entferne zuerst den Vault, der dorthin synchronisiert.";
+"This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again." = "Diese Freigabe soll nach „%@“ synchronisieren, aber dieser Ort überlappt jetzt einen Ordner, den ein anderer Vault bereits synchronisiert. Tippe bei der Freigabe auf „Vault wählen…“, um einen neuen Ort zu wählen, oder entferne den Vault, der dorthin synchronisiert, und nimm die Freigabe erneut an.";
 "View Cloud Relay" = "Cloud Relay ansehen";
 "XXXXXXX-XXXXXXX-..." = "XXXXXXX-XXXXXXX-...";
 "Retry APNs Registration" = "APNs-Registrierung erneut versuchen";
@@ -621,12 +635,12 @@
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Zwei Vaults teilen sich einen Ordner";
 "Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage." = "Zwei oder mehr Vaults synchronisieren in denselben lokalen Ordner, sodass ihre Inhalte vermischt werden. Die betroffenen Vaults wurden pausiert, um weiteren Schaden zu verhindern.";
-"Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Entferne einen betroffenen Vault auf diesem iPhone – er wird automatisch wieder in seinem eigenen Ordner hinzugefügt. Sind die Dateien bereits vermischt, stelle zuerst die saubere Kopie auf deinem Computer wieder her.";
+"Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Entferne einen betroffenen Vault auf diesem iPhone und nimm ihn unter „Ausstehende Freigaben“ erneut an – er zieht in seinen eigenen Ordner. Sind die Dateien bereits vermischt, stelle zuerst die saubere Kopie auf deinem Computer wieder her.";
 
 /* Nested vaults (#45 follow-up) — a share may never nest inside another vault's folder */
 "One Vault Is Nested Inside Another" = "Ein Vault liegt in einem anderen Vault";
 "A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing." = "Der Ordner eines Vaults liegt im Ordner eines anderen Vaults, daher synchronisiert der äußere Vault die Notizen des inneren Vaults auf seine eigenen Geräte. Die betroffenen Vaults wurden pausiert, um weitere Vermischung zu stoppen.";
-"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Wähle als Obsidian-Verzeichnis von VaultSync den Ordner aus, der deine Vaults enthält („Auf meinem iPhone“ → „Obsidian“), und entferne dann den inneren Vault auf diesem iPhone – er wird automatisch wieder in seinem eigenen Ordner hinzugefügt. Lösche erst danach die übrig gebliebene Kopie im äußeren Vault auf deinen anderen Geräten.";
+"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Wähle als Obsidian-Verzeichnis von VaultSync den Ordner aus, der deine Vaults enthält („Auf meinem iPhone“ → „Obsidian“), entferne dann den inneren Vault auf diesem iPhone und nimm ihn unter „Ausstehende Freigaben“ erneut an – er erhält seinen eigenen Ordner. Lösche erst danach die übrig gebliebene Kopie im äußeren Vault auf deinen anderen Geräten.";
 "This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other." = "Diese Freigabe braucht einen eigenen Ordner, aber der für VaultSync ausgewählte Ordner ist selbst ein Vault – alles darin gehört zu diesem Vault. Wähle den Ordner neu aus, der deine Vaults enthält („Auf meinem iPhone“ → „Obsidian“) – neue Vaults synchronisieren dann nebeneinander statt ineinander.";
 "The folder you selected is itself a vault. Syncing this one vault works, but additional vaults cannot get their own folder next to it. If you plan to sync more than one vault, select the folder that contains your vaults instead (\"On My iPhone\" → \"Obsidian\")." = "Der ausgewählte Ordner ist selbst ein Vault. Diesen einen Vault kannst du so synchronisieren, aber weitere Vaults können keinen eigenen Ordner daneben bekommen. Wenn du mehr als einen Vault synchronisieren möchtest, wähle stattdessen den Ordner aus, der deine Vaults enthält („Auf meinem iPhone“ → „Obsidian“).";
 "Note" = "Hinweis";

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -29,6 +29,9 @@
 "Check your connection and retry." = "Check your connection and retry.";
 "Check your internet connection and try the relay health check again on the Relay tab." = "Check your internet connection and try the relay health check again on the Relay tab.";
 "Check your subscription status on the Relay tab and retry. If this persists, restart VaultSync." = "Check your subscription status on the Relay tab and retry. If this persists, restart VaultSync.";
+"Choose Vault" = "Choose Vault";
+"Choose Vault…" = "Choose Vault…";
+"Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices." = "Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices.";
 "Cloud Relay" = "Cloud Relay";
 "Cloud Relay active" = "Cloud Relay active";
 "Cloud Relay is not currently subscribed. Push-triggered wake-ups are disabled until the subscription is active." = "Cloud Relay is not currently subscribed. Push-triggered wake-ups are disabled until the subscription is active.";
@@ -62,6 +65,7 @@
 "Could not read files.\n\n%@\n%@" = "Could not read files.\n\n%@\n%@";
 "Could not read original file.\n\n%@" = "Could not read original file.\n\n%@";
 "Create a vault in Obsidian first. VaultSync will detect it automatically." = "Create a vault in Obsidian first. VaultSync will detect it automatically.";
+"Creates a folder with this name in your Obsidian directory and syncs the share into it." = "Creates a folder with this name in your Obsidian directory and syncs the share into it.";
 "Device" = "Device";
 "Device ID" = "Device ID";
 "%d of %d devices connected" = "%d of %d devices connected";
@@ -72,13 +76,16 @@
 "Done" = "Done";
 "Empty line" = "Empty line";
 "Enable notifications for VaultSync in iOS Settings → Notifications → VaultSync, then restart the app." = "Enable notifications for VaultSync in iOS Settings → Notifications → VaultSync, then restart the app.";
+"Enter a folder name." = "Enter a folder name.";
 "Error" = "Error";
+"Existing Empty Vaults" = "Existing Empty Vaults";
 "Failed" = "Failed";
 "Failed to save access permission: %@" = "Failed to save access permission: %@";
 "Failed to sync file in %@" = "Failed to sync file in %@";
 "File Read Failed" = "File Read Failed";
 "File synced in %@" = "File synced in %@";
 "Files are being synchronized with peers." = "Files are being synchronized with peers.";
+"Folder name" = "Folder name";
 "Folder Not Configured" = "Folder Not Configured";
 "Folder Path Missing" = "Folder Path Missing";
 "Folder Permission Error" = "Folder Permission Error";
@@ -118,6 +125,7 @@
 "Last sync: %@" = "Last sync: %@";
 "Latency" = "Latency";
 "Learn how to fix" = "Learn how to fix";
+"Link Share" = "Link Share";
 "Loading…" = "Loading…";
 "Local Files" = "Local Files";
 "Log" = "Log";
@@ -128,6 +136,8 @@
 "Needs Attention" = "Needs Attention";
 "Network Error" = "Network Error";
 "Never" = "Never";
+"New Folder" = "New Folder";
+"No empty vaults found. Create the vault in Obsidian first, or use a new folder below." = "No empty vaults found. Create the vault in Obsidian first, or use a new folder below.";
 "No Syncthing peers available yet." = "No Syncthing peers available yet.";
 "No action needed." = "No action needed.";
 "No active pending shares" = "No active pending shares";
@@ -152,6 +162,7 @@
 "Obsidian directory not accessible." = "Obsidian directory not accessible.";
 "Obsidian folder not connected" = "Obsidian folder not connected";
 "Offline" = "Offline";
+"Only vaults without any notes yet can be linked to a share." = "Only vaults without any notes yet can be linked to a share.";
 "Open Settings" = "Open Settings";
 "Open the Relay tab" = "Open the Relay tab";
 "Open VaultSync" = "Open VaultSync";
@@ -233,6 +244,9 @@
 "Purchase Failed" = "Purchase Failed";
 "Rescan All Vaults" = "Rescan All Vaults";
 "Sync Conflicts" = "Sync Conflicts";
+"The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name." = "The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name.";
+"The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first." = "The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first.";
+"This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again." = "This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again.";
 "View Cloud Relay" = "View Cloud Relay";
 "XXXXXXX-XXXXXXX-..." = "XXXXXXX-XXXXXXX-...";
 "Retry APNs Registration" = "Retry APNs Registration";
@@ -621,12 +635,12 @@
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Two Vaults Are Sharing One Folder";
 "Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage." = "Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage.";
-"Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first.";
+"Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first.";
 
 /* Nested vaults (#45 follow-up) — a share may never nest inside another vault's folder */
 "One Vault Is Nested Inside Another" = "One Vault Is Nested Inside Another";
 "A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing." = "A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing.";
-"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices.";
+"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices.";
 "This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other." = "This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other.";
 "The folder you selected is itself a vault. Syncing this one vault works, but additional vaults cannot get their own folder next to it. If you plan to sync more than one vault, select the folder that contains your vaults instead (\"On My iPhone\" → \"Obsidian\")." = "The folder you selected is itself a vault. Syncing this one vault works, but additional vaults cannot get their own folder next to it. If you plan to sync more than one vault, select the folder that contains your vaults instead (\"On My iPhone\" → \"Obsidian\").";
 "Note" = "Note";

--- a/ios/VaultSync/es.lproj/Localizable.strings
+++ b/ios/VaultSync/es.lproj/Localizable.strings
@@ -29,6 +29,9 @@
 "Check your connection and retry." = "Comprueba tu conexión y vuelve a intentarlo.";
 "Check your internet connection and try the relay health check again on the Relay tab." = "Comprueba tu conexión a internet y vuelve a ejecutar la comprobación de estado del Relay en la pestaña Relay.";
 "Check your subscription status on the Relay tab and retry. If this persists, restart VaultSync." = "Comprueba el estado de tu suscripción en la pestaña Relay y vuelve a intentarlo. Si continúa, reinicia VaultSync.";
+"Choose Vault" = "Elegir Vault";
+"Choose Vault…" = "Elegir Vault…";
+"Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices." = "Elige dónde se sincroniza \"%@\" en este iPhone. La compartición conserva su nombre en tus otros dispositivos.";
 "Cloud Relay" = "Cloud Relay";
 "Cloud Relay active" = "Cloud Relay activo";
 "Cloud Relay is not currently subscribed. Push-triggered wake-ups are disabled until the subscription is active." = "Cloud Relay no está suscrito actualmente. Las señales de activación por push están desactivadas hasta que la suscripción esté activa.";
@@ -62,6 +65,7 @@
 "Could not read files.\n\n%@\n%@" = "No se pudieron leer los archivos.\n\n%@\n%@";
 "Could not read original file.\n\n%@" = "No se pudo leer el archivo original.\n\n%@";
 "Create a vault in Obsidian first. VaultSync will detect it automatically." = "Crea primero un Vault en Obsidian. VaultSync lo detectará automáticamente.";
+"Creates a folder with this name in your Obsidian directory and syncs the share into it." = "Crea una carpeta con este nombre en tu directorio de Obsidian y sincroniza la compartición en ella.";
 "Device" = "Dispositivo";
 "Device ID" = "ID del dispositivo";
 "%d of %d devices connected" = "%d de %d dispositivos conectados";
@@ -72,13 +76,16 @@
 "Done" = "Listo";
 "Empty line" = "Línea vacía";
 "Enable notifications for VaultSync in iOS Settings → Notifications → VaultSync, then restart the app." = "Activa las notificaciones de VaultSync en Ajustes de iOS → Notificaciones → VaultSync y luego reinicia la app.";
+"Enter a folder name." = "Introduce un nombre de carpeta.";
 "Error" = "Error";
+"Existing Empty Vaults" = "Vaults vacíos existentes";
 "Failed" = "Fallido";
 "Failed to save access permission: %@" = "No se pudo guardar el permiso de acceso: %@";
 "Failed to sync file in %@" = "No se pudo sincronizar el archivo en %@";
 "File Read Failed" = "No se pudo leer el archivo";
 "File synced in %@" = "Archivo sincronizado en %@";
 "Files are being synchronized with peers." = "Los archivos se están sincronizando con los pares.";
+"Folder name" = "Nombre de la carpeta";
 "Folder Not Configured" = "Carpeta no configurada";
 "Folder Path Missing" = "Falta la ruta de la carpeta";
 "Folder Permission Error" = "Error de permisos de la carpeta";
@@ -118,6 +125,7 @@
 "Last sync: %@" = "Última sincronización: %@";
 "Latency" = "Latencia";
 "Learn how to fix" = "Aprende a solucionarlo";
+"Link Share" = "Vincular compartición";
 "Loading…" = "Cargando…";
 "Local Files" = "Archivos locales";
 "Log" = "Registro";
@@ -128,6 +136,8 @@
 "Needs Attention" = "Requiere atención";
 "Network Error" = "Error de red";
 "Never" = "Nunca";
+"New Folder" = "Carpeta nueva";
+"No empty vaults found. Create the vault in Obsidian first, or use a new folder below." = "No se encontraron Vaults vacíos. Crea primero el Vault en Obsidian o usa una carpeta nueva más abajo.";
 "No Syncthing peers available yet." = "Aún no hay pares de Syncthing disponibles.";
 "No action needed." = "No se requiere ninguna acción.";
 "No active pending shares" = "No hay comparticiones pendientes activas";
@@ -152,6 +162,7 @@
 "Obsidian directory not accessible." = "No se puede acceder al directorio de Obsidian.";
 "Obsidian folder not connected" = "Carpeta de Obsidian no conectada";
 "Offline" = "Sin conexión";
+"Only vaults without any notes yet can be linked to a share." = "Solo los Vaults que aún no contienen notas pueden vincularse a una compartición.";
 "Open Settings" = "Abrir Ajustes";
 "Open the Relay tab" = "Abrir la pestaña Relay";
 "Open VaultSync" = "Abrir VaultSync";
@@ -233,6 +244,9 @@
 "Purchase Failed" = "La compra falló";
 "Rescan All Vaults" = "Reescanear todos los Vaults";
 "Sync Conflicts" = "Conflictos de sincronización";
+"The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name." = "La carpeta \"%@\" ya contiene archivos. Una compartición solo puede vincularse a un Vault vacío: elige un Vault vacío o introduce un nombre de carpeta nuevo.";
+"The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first." = "La carpeta de destino \"%@\" ya se sincroniza con otro Vault: la misma carpeta, o una superior o interior. Elige otra carpeta o elimina primero el Vault que se sincroniza ahí.";
+"This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again." = "Esta compartición está configurada para sincronizarse en \"%@\", pero esa ubicación ahora se superpone con una carpeta que otro Vault ya sincroniza. Toca \"Elegir Vault…\" en la compartición para elegir otra ubicación, o elimina el Vault que se sincroniza ahí y acepta la compartición de nuevo.";
 "View Cloud Relay" = "Ver Cloud Relay";
 "XXXXXXX-XXXXXXX-..." = "XXXXXXX-XXXXXXX-...";
 "Retry APNs Registration" = "Reintentar registro de APNs";
@@ -621,12 +635,12 @@
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Dos Vaults comparten una misma carpeta";
 "Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage." = "Dos o más Vaults se sincronizan en la misma carpeta local, por lo que sus contenidos se están mezclando. Los Vaults afectados se han pausado para evitar más daños.";
-"Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Elimina un Vault afectado en este iPhone: se volverá a añadir automáticamente en su propia carpeta. Si los archivos ya están mezclados, restaura primero la copia limpia en tu equipo.";
+"Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "Elimina un Vault afectado en este iPhone y acéptalo de nuevo en \"Comparticiones pendientes\": pasará a su propia carpeta. Si los archivos ya están mezclados, restaura primero la copia limpia en tu equipo.";
 
 /* Nested vaults (#45 follow-up) — a share may never nest inside another vault's folder */
 "One Vault Is Nested Inside Another" = "Un Vault está anidado dentro de otro";
 "A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing." = "La carpeta de un Vault está dentro de la carpeta de otro Vault, por lo que el Vault exterior sincroniza las notas del Vault interior con sus propios dispositivos. Los Vaults afectados se han pausado para detener más mezclas.";
-"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Selecciona como directorio de Obsidian de VaultSync la carpeta que contiene tus Vaults (\"En mi iPhone\" → \"Obsidian\") y luego elimina el Vault interior en este iPhone: se volverá a añadir en su propia carpeta. Solo después, borra la copia restante dentro del Vault exterior en tus otros dispositivos.";
+"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "Selecciona como directorio de Obsidian de VaultSync la carpeta que contiene tus Vaults (\"En mi iPhone\" → \"Obsidian\"), luego elimina el Vault interior en este iPhone y acéptalo de nuevo en \"Comparticiones pendientes\": obtendrá su propia carpeta. Solo después, borra la copia restante dentro del Vault exterior en tus otros dispositivos.";
 "This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other." = "Este recurso compartido necesita su propia carpeta, pero la carpeta seleccionada para VaultSync es en sí misma un Vault, así que todo lo que contiene pertenece a ese Vault. Vuelve a seleccionar la carpeta que contiene tus Vaults (\"En mi iPhone\" → \"Obsidian\"): los Vaults nuevos se sincronizarán uno junto a otro en lugar de uno dentro de otro.";
 "The folder you selected is itself a vault. Syncing this one vault works, but additional vaults cannot get their own folder next to it. If you plan to sync more than one vault, select the folder that contains your vaults instead (\"On My iPhone\" → \"Obsidian\")." = "La carpeta seleccionada es en sí misma un Vault. Sincronizar este único Vault funciona, pero los Vaults adicionales no podrán tener su propia carpeta junto a él. Si piensas sincronizar más de un Vault, selecciona en su lugar la carpeta que contiene tus Vaults (\"En mi iPhone\" → \"Obsidian\").";
 "Note" = "Nota";

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -29,6 +29,9 @@
 "Check your connection and retry." = "检查网络连接后重试。";
 "Check your internet connection and try the relay health check again on the Relay tab." = "检查网络连接，然后在 Relay 标签页中重新执行 Relay 健康检查。";
 "Check your subscription status on the Relay tab and retry. If this persists, restart VaultSync." = "在 Relay 标签页中检查订阅状态后重试。如果问题持续存在，请重启 VaultSync。";
+"Choose Vault" = "选择 Vault";
+"Choose Vault…" = "选择 Vault…";
+"Choose where \"%@\" syncs on this iPhone. The share keeps its name on your other devices." = "选择“%@”在此 iPhone 上的同步位置。共享在你其他设备上的名称保持不变。";
 "Cloud Relay" = "Cloud Relay";
 "Cloud Relay active" = "Cloud Relay 已启用";
 "Cloud Relay is not currently subscribed. Push-triggered wake-ups are disabled until the subscription is active." = "当前未订阅 Cloud Relay。在订阅激活前，基于推送的唤醒功能将被禁用。";
@@ -62,6 +65,7 @@
 "Could not read files.\n\n%@\n%@" = "无法读取文件。\n\n%@\n%@";
 "Could not read original file.\n\n%@" = "无法读取原始文件。\n\n%@";
 "Create a vault in Obsidian first. VaultSync will detect it automatically." = "请先在 Obsidian 中创建一个 Vault。VaultSync 会自动检测到它。";
+"Creates a folder with this name in your Obsidian directory and syncs the share into it." = "在你的 Obsidian 目录中创建一个此名称的文件夹，并将共享同步到其中。";
 "Device" = "设备";
 "Device ID" = "设备 ID";
 "%d of %d devices connected" = "已连接 %d/%d 台设备";
@@ -72,13 +76,16 @@
 "Done" = "完成";
 "Empty line" = "空行";
 "Enable notifications for VaultSync in iOS Settings → Notifications → VaultSync, then restart the app." = "请在 iOS 设置 → 通知 → VaultSync 中启用通知，然后重新启动应用。";
+"Enter a folder name." = "请输入文件夹名称。";
 "Error" = "错误";
+"Existing Empty Vaults" = "现有的空 Vault";
 "Failed" = "失败";
 "Failed to save access permission: %@" = "保存访问权限失败：%@";
 "Failed to sync file in %@" = "同步 %@ 中的文件失败";
 "File Read Failed" = "读取文件失败";
 "File synced in %@" = "已同步 %@ 中的文件";
 "Files are being synchronized with peers." = "文件正在与对端同步。";
+"Folder name" = "文件夹名称";
 "Folder Not Configured" = "文件夹未配置";
 "Folder Path Missing" = "文件夹路径缺失";
 "Folder Permission Error" = "文件夹权限错误";
@@ -118,6 +125,7 @@
 "Last sync: %@" = "上次同步：%@";
 "Latency" = "延迟";
 "Learn how to fix" = "查看修复方法";
+"Link Share" = "关联共享";
 "Loading…" = "正在加载…";
 "Local Files" = "本地文件";
 "Log" = "日志";
@@ -128,6 +136,8 @@
 "Needs Attention" = "需要处理";
 "Network Error" = "网络错误";
 "Never" = "从未";
+"New Folder" = "新文件夹";
+"No empty vaults found. Create the vault in Obsidian first, or use a new folder below." = "未找到空 Vault。请先在 Obsidian 中创建 Vault，或在下方使用新文件夹。";
 "No Syncthing peers available yet." = "尚无可用的 Syncthing 对端。";
 "No action needed." = "无需操作。";
 "No active pending shares" = "没有活动的待处理共享";
@@ -152,6 +162,7 @@
 "Obsidian directory not accessible." = "无法访问 Obsidian 目录。";
 "Obsidian folder not connected" = "Obsidian 文件夹未连接";
 "Offline" = "离线";
+"Only vaults without any notes yet can be linked to a share." = "只有尚未包含笔记的 Vault 才能与共享关联。";
 "Open Settings" = "打开设置";
 "Open the Relay tab" = "打开 Relay 标签页";
 "Open VaultSync" = "打开 VaultSync";
@@ -233,6 +244,9 @@
 "Purchase Failed" = "购买失败";
 "Rescan All Vaults" = "重新扫描所有 Vault";
 "Sync Conflicts" = "同步冲突";
+"The folder \"%@\" already contains files. A share can only be linked to an empty vault — choose an empty vault, or enter a new folder name." = "文件夹“%@”中已包含文件。共享只能与空 Vault 关联——请选择一个空 Vault，或输入新的文件夹名称。";
+"The target folder \"%@\" is already synced by another vault — the same folder, or one above or inside it. Choose a different folder, or remove the vault that syncs there first." = "目标文件夹“%@”已由另一个 Vault 同步——同一文件夹，或其上层或内部的文件夹。请选择其他文件夹，或先移除同步到该位置的 Vault。";
+"This share is set to sync into \"%@\", but that location now overlaps a folder another vault already syncs. Tap \"Choose Vault…\" on the share to pick a new location, or remove the vault that syncs there, then accept the share again." = "此共享设置为同步到“%@”，但该位置现在与另一个 Vault 已同步的文件夹重叠。请在共享上点按“选择 Vault…”选择新位置，或移除同步到该位置的 Vault，然后重新接受此共享。";
 "View Cloud Relay" = "查看 Cloud Relay";
 "XXXXXXX-XXXXXXX-..." = "XXXXXXX-XXXXXXX-...";
 "Retry APNs Registration" = "重试 APNs 注册";
@@ -621,12 +635,12 @@
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "两个 Vault 共用同一个文件夹";
 "Two or more vaults sync into the same local folder, so their contents are being mixed together. The affected vaults have been paused to stop further damage." = "两个或更多 Vault 同步到同一个本地文件夹，导致它们的内容被混在一起。受影响的 Vault 已被暂停，以防止进一步损坏。";
-"Remove an affected vault on this iPhone — it is added back automatically into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "在此 iPhone 上移除一个受影响的 Vault——它会自动重新添加到自己的文件夹中。如果文件已经混在一起，请先在电脑上恢复干净的副本。";
+"Remove an affected vault on this iPhone, then accept it again under Pending Shares — it moves into its own folder. If the files are already mixed, restore the clean copy on your computer first." = "在此 iPhone 上移除一个受影响的 Vault，然后在“待处理共享”中重新接受它——它会移入自己的文件夹。如果文件已经混在一起，请先在电脑上恢复干净的副本。";
 
 /* Nested vaults (#45 follow-up) — a share may never nest inside another vault's folder */
 "One Vault Is Nested Inside Another" = "一个 Vault 嵌套在另一个 Vault 中";
 "A vault's folder is inside another vault's folder, so the outer vault syncs the inner vault's notes to its own devices. The affected vaults have been paused to stop further mixing." = "一个 Vault 的文件夹位于另一个 Vault 的文件夹内，因此外层 Vault 会把内层 Vault 的笔记同步到它自己的设备上。受影响的 Vault 已被暂停，以防止进一步混合。";
-"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone — it is added back into its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "将包含所有 Vault 的文件夹（“在我的 iPhone 上” → “Obsidian”）设为 VaultSync 的 Obsidian 目录，然后在此 iPhone 上移除内层 Vault——它会自动重新添加到自己的文件夹中。之后再删除其他设备上外层 Vault 中遗留的副本。";
+"Select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") as VaultSync's Obsidian directory, then remove the inner vault on this iPhone and accept it again under Pending Shares — it gets its own folder. Only afterwards, delete the leftover copy inside the outer vault on your other devices." = "将包含所有 Vault 的文件夹（“在我的 iPhone 上” → “Obsidian”）设为 VaultSync 的 Obsidian 目录，然后在此 iPhone 上移除内层 Vault 并在“待处理共享”中重新接受它——它会获得自己的文件夹。之后再删除其他设备上外层 Vault 中遗留的副本。";
 "This share needs its own folder, but the folder selected for VaultSync is itself a vault, so everything inside it belongs to that vault. Re-select the folder that contains your vaults (\"On My iPhone\" → \"Obsidian\") — new vaults then sync side by side instead of inside each other." = "此共享需要自己的文件夹，但为 VaultSync 选择的文件夹本身就是一个 Vault，其中的所有内容都属于该 Vault。请重新选择包含所有 Vault 的文件夹（“在我的 iPhone 上” → “Obsidian”）——这样新的 Vault 会并排同步，而不会嵌套在一起。";
 "The folder you selected is itself a vault. Syncing this one vault works, but additional vaults cannot get their own folder next to it. If you plan to sync more than one vault, select the folder that contains your vaults instead (\"On My iPhone\" → \"Obsidian\")." = "所选文件夹本身就是一个 Vault。这样同步这一个 Vault 没有问题，但其他 Vault 将无法在它旁边获得自己的文件夹。如果你打算同步多个 Vault，请改为选择包含所有 Vault 的文件夹（“在我的 iPhone 上” → “Obsidian”）。";
 "Note" = "提示";

--- a/ios/VaultSyncTests/ManualShareTargetTests.swift
+++ b/ios/VaultSyncTests/ManualShareTargetTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import Testing
+@testable import VaultSync
+
+@Suite("Manual share target & user-removed re-accept (#52)")
+struct ManualShareTargetTests {
+
+    /// Production passes `FolderPathReconciler.canonical`; tests inject identity
+    /// so the decision logic is exercised without touching the filesystem. The
+    /// functions lowercase internally, so occupied entries are supplied lowercased.
+    private let identity: (String) -> String = { $0 }
+
+    private func occupied(_ paths: String...) -> Set<String> {
+        Set(paths.map { $0.lowercased() })
+    }
+
+    private func validate(
+        root: String = "/Obsidian",
+        name: String,
+        occupied: Set<String> = [],
+        entries: [String]? = nil
+    ) -> ShareTargetDecision {
+        VaultManager.validateManualTarget(
+            rawRoot: root,
+            name: name,
+            occupiedCanonLower: occupied,
+            targetEntries: entries,
+            canonicalize: identity
+        )
+    }
+
+    private func resolve(
+        manualTarget: String?,
+        root: String = "/Obsidian",
+        baseIsVault: Bool = false,
+        nameMatchesBase: Bool = false,
+        name: String,
+        occupied: Set<String> = []
+    ) -> ShareTargetDecision {
+        VaultManager.resolveAcceptPath(
+            manualTarget: manualTarget,
+            rawRoot: root,
+            baseIsVault: baseIsVault,
+            nameMatchesBase: nameMatchesBase,
+            folderName: name,
+            occupiedCanonLower: occupied,
+            canonicalize: identity
+        )
+    }
+
+    // MARK: - Empty-vault eligibility (pure core)
+
+    @Test("An empty directory is an eligible target")
+    func emptyListingIsEligible() {
+        #expect(VaultManager.isEmptyVaultListing([]))
+    }
+
+    @Test("A vault holding only .obsidian is eligible, in any case spelling")
+    func obsidianOnlyIsEligible() {
+        #expect(VaultManager.isEmptyVaultListing([".obsidian"]))
+        #expect(VaultManager.isEmptyVaultListing([".Obsidian"]))
+    }
+
+    @Test("Notes, hidden leftovers, or a sync marker disqualify a target")
+    func contentDisqualifies() {
+        #expect(!VaultManager.isEmptyVaultListing(["Note.md"]))
+        #expect(!VaultManager.isEmptyVaultListing([".obsidian", "Daily"]))
+        #expect(!VaultManager.isEmptyVaultListing([".stfolder"]))
+        #expect(!VaultManager.isEmptyVaultListing([".DS_Store"]))
+    }
+
+    // MARK: - validateManualTarget
+
+    @Test("A fresh folder name maps to its own subdirectory under the root")
+    func freshNameMapsUnderRoot() {
+        #expect(validate(name: "Life") == .path("/Obsidian/Life"))
+    }
+
+    @Test("An existing empty vault is accepted as target")
+    func existingEmptyVaultAccepted() {
+        #expect(validate(name: "Life", entries: [".obsidian"]) == .path("/Obsidian/Life"))
+    }
+
+    @Test("A blank name is refused with guidance")
+    func blankNameRefused() {
+        guard case .refused(let message) = validate(name: "   ") else {
+            Issue.record("expected a refusal for a blank name")
+            return
+        }
+        #expect(message.contains("folder name"))
+    }
+
+    @Test("Invalid path characters are sanitized, not refused")
+    func invalidCharactersSanitized() {
+        #expect(validate(name: "Life/2026") == .path("/Obsidian/Life-2026"))
+    }
+
+    @Test("A target that is another vault's directory is refused, case-insensitively")
+    func overlapSameDirectoryRefused() {
+        guard case .refused(let message) = validate(name: "LIFE", occupied: occupied("/obsidian/life")) else {
+            Issue.record("expected a refusal for an occupied directory")
+            return
+        }
+        // Names the folder, states the reason, gives the next step.
+        #expect(message.contains("LIFE"))
+        #expect(message.contains("already synced by another vault"))
+        #expect(message.contains("Choose a different folder"))
+    }
+
+    @Test("A target holding another vault's directory deeper down is refused")
+    func overlapContainingOccupiedRefused() {
+        guard case .refused = validate(name: "Life", occupied: occupied("/obsidian/life/attachments")) else {
+            Issue.record("expected a refusal for a target containing an occupied directory")
+            return
+        }
+    }
+
+    @Test("A non-empty folder is refused: linking would merge two content sets")
+    func nonEmptyTargetRefused() {
+        guard case .refused(let message) = validate(name: "Life", entries: [".obsidian", "Note.md"]) else {
+            Issue.record("expected a refusal for a non-empty target")
+            return
+        }
+        #expect(message.contains("Life"))
+        #expect(message.contains("empty vault"))
+    }
+
+    @Test("#45 follow-up: a compromised root refuses every manual target")
+    func compromisedRootRefused() {
+        guard case .refused(let message) = validate(name: "Life", occupied: occupied("/obsidian")) else {
+            Issue.record("expected a refusal when the root lies in an occupied directory")
+            return
+        }
+        #expect(message.contains("contains your vaults"))
+    }
+
+    // MARK: - resolveAcceptPath (override precedence)
+
+    @Test("Without an override the label-derived mapping applies")
+    func noOverrideUsesLabelMapping() {
+        #expect(
+            resolve(manualTarget: nil, name: "Obsidian-Vault-Life")
+                == .path("/Obsidian/Obsidian-Vault-Life")
+        )
+    }
+
+    @Test("A stored manual target wins over the share-label default")
+    func overrideWinsOverLabelDefault() {
+        #expect(
+            resolve(manualTarget: "Life", name: "Obsidian-Vault-Life")
+                == .path("/Obsidian/Life")
+        )
+    }
+
+    @Test("The override also suppresses the collapse-into-root shortcuts")
+    func overrideSuppressesRootCollapse() {
+        #expect(
+            resolve(manualTarget: "Life", baseIsVault: true, name: "Obsidian-Vault-Life")
+                == .path("/Obsidian/Life")
+        )
+    }
+
+    @Test("#52: an unsafe override is refused with path, reason, and next step — never a silent fallback")
+    func unsafeOverrideRefusedWithGuidance() {
+        let decision = resolve(
+            manualTarget: "Life",
+            name: "Obsidian-Vault-Life",
+            occupied: occupied("/obsidian/life")
+        )
+        guard case .refused(let message) = decision else {
+            Issue.record("an unsafe override must refuse, not fall back to the share-label default")
+            return
+        }
+        // Names the stored location…
+        #expect(message.contains("\"Life\""))
+        // …states the reason…
+        #expect(message.contains("overlaps"))
+        // …and tells the user the next step.
+        #expect(message.contains("Choose Vault…"))
+        #expect(message.contains("remove the vault"))
+    }
+
+    @Test("An override whose directory holds another vault deeper down is refused")
+    func overrideContainingOccupiedRefused() {
+        guard case .refused = resolve(
+            manualTarget: "Life",
+            name: "Obsidian-Vault-Life",
+            occupied: occupied("/obsidian/life/inner")
+        ) else {
+            Issue.record("expected a refusal for an override containing an occupied directory")
+            return
+        }
+    }
+
+    @Test("Refusal without a safe location keeps the container-folder guidance")
+    func labelRefusalKeepsGuidance() {
+        guard case .refused(let message) = resolve(
+            manualTarget: nil,
+            baseIsVault: true,
+            name: "Second",
+            occupied: occupied("/obsidian")
+        ) else {
+            Issue.record("expected a refusal when no safe location exists")
+            return
+        }
+        #expect(message.contains("contains your vaults"))
+    }
+
+    // MARK: - Manual target sidecar
+
+    @Test("Sidecar set / read round-trips through UserDefaults and overwrites cleanly")
+    func sidecarRoundTrip() {
+        UserDefaults.standard.removeObject(forKey: "vaultsync.manualShareTargets")
+        #expect(ManualShareTargetStore.target(forFolder: "f1") == nil)
+
+        ManualShareTargetStore.setTarget("Life", forFolder: "f1")
+        #expect(ManualShareTargetStore.target(forFolder: "f1") == "Life")
+        #expect(ManualShareTargetStore.target(forFolder: "other") == nil)
+
+        ManualShareTargetStore.setTarget("Work", forFolder: "f1")
+        #expect(ManualShareTargetStore.target(forFolder: "f1") == "Work")
+
+        UserDefaults.standard.removeObject(forKey: "vaultsync.manualShareTargets")
+    }
+
+    // MARK: - Auto-accept suppression for user-removed folders
+
+    @Test("#52: a share whose folder the user removed is not auto-accept eligible")
+    func userRemovedSharesAreSkipped() {
+        let pending = [
+            SyncthingManager.PendingFolderInfo(id: "keep", label: "Keep", offeredBy: []),
+            SyncthingManager.PendingFolderInfo(id: "removed", label: "Removed", offeredBy: []),
+        ]
+        let eligible = SyncthingManager.autoAcceptEligible(actionable: pending, userRemoved: ["removed"])
+        #expect(eligible.map(\.id) == ["keep"])
+    }
+
+    @Test("Nothing is suppressed while the user has removed nothing")
+    func noSuppressionByDefault() {
+        let pending = [SyncthingManager.PendingFolderInfo(id: "a", label: "A", offeredBy: [])]
+        #expect(SyncthingManager.autoAcceptEligible(actionable: pending, userRemoved: []).map(\.id) == ["a"])
+    }
+
+    @Test("The user-removed set is restored across launches")
+    @MainActor
+    func userRemovedSetPersists() {
+        UserDefaults.standard.set(["f1"], forKey: "syncthing.userRemovedFolderIDs")
+        defer { UserDefaults.standard.removeObject(forKey: "syncthing.userRemovedFolderIDs") }
+
+        let manager = SyncthingManager()
+        #expect(manager.userRemovedFolderIDs == ["f1"])
+    }
+}


### PR DESCRIPTION
Closes #52. Adds a per-share "Choose Vault…" picker (existing empty vault or custom-named new folder; share label on peers untouched), persists the choice per folder ID so remove + re-accept returns to the chosen location (unsafe override → refusal with guidance, never a silent fallback), and stops auto-re-accepting shares whose vault the user removed (doctrine 002, decision 006) — which also makes Remove Vault actually stick while a peer keeps sharing. #45 overlap guards untouched (shared Swift predicate + Go hard floor); no go/ change, no xcframework rebuild. 18 new tests in ManualShareTargetTests; strings in EN/DE/ES/zh-Hans. Note for review: Swift suite not run locally (Linux) — please rely on the macOS Build & Test job / run the test plan before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a manual “Choose Vault…” flow for accepting incoming shares on iOS. Users can now link a share to an existing empty vault or create a new local folder with a custom name, while the Syncthing share label stays unchanged.

It also makes manual target selection persistent per folder ID, so removing and re-accepting a share returns it to the same location. If a saved target becomes unsafe, the app now refuses to auto-fallback and shows guidance instead. Removed vaults also stay removed instead of being silently re-added by background auto-accept.

Updated coverage includes new tests for manual target validation, path resolution, persistence, and user-removed share suppression, plus localized strings and documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->