### PR TITLE
fix(ios): retry pending shares right after reconnecting the Obsidian folder (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to VaultSync are documented here.
 
 - **Choose where a share syncs** ([#52](https://github.com/psimaker/vaultsync/issues/52)) — a new "Choose Vault…" option on every pending share lets you pick an existing *empty* vault (create the vault in Obsidian first, then link the share to it) or create a folder with a name of your choice, instead of the automatic folder named after the share — share names like "Obsidian-Vault-Life" no longer dictate your local vault name. VaultSync remembers the choice: remove the vault and accept the share again, and it returns to the folder you picked — never silently to the automatic one. Locations that overlap another vault's folder are refused at every layer, and only empty vaults can be linked, so two vaults can never mix (the #45 guarantees are untouched). Localized in English, German, Spanish, and Simplified Chinese.
 
+### Fixed
+
+- **Waiting shares are picked up right after reconnecting the Obsidian folder** ([#53](https://github.com/psimaker/vaultsync/issues/53)) — after re-selecting the Obsidian folder, a share that had been waiting (for example because the folder connection was broken, or because there was no safe location under the previously selected folder) was not retried until some unrelated event — often not before an app restart. Reconnecting now retries waiting shares immediately — and only after the vault locations have settled against the newly selected folder, so the safety checks judge against current locations, never stale ones.
+
 ## [1.7.2] — 2026-07-07
 
 ### Fixed

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -672,11 +672,17 @@ final class SyncthingManager {
     /// Obsidian root before a stale path can strand a folder in a permanent
     /// access error (issue #25). Safe to call on every engine start — unchanged
     /// paths are a no-op. The blocking bridge work runs off the main actor.
-    func reconcileFolderPaths(obsidianRoot: String?) {
-        guard isRunning else { return }
+    ///
+    /// Returns the reconcile task so a caller can sequence work after paths
+    /// have settled: an accept pass that runs concurrently would compute its
+    /// occupied-path set from the pre-reconcile folder list — stale exactly
+    /// when the user is repairing a container move (#53).
+    @discardableResult
+    func reconcileFolderPaths(obsidianRoot: String?) -> Task<Void, Never> {
+        guard isRunning else { return Task {} }
         // Run the blocking bridge work off the main actor; only the final
         // folder-list refresh hops back to the main actor.
-        Task.detached(priority: .utility) { [weak self] in
+        return Task.detached(priority: .utility) { [weak self] in
             // Wait briefly for the engine to load its folder list after start.
             for _ in 0..<12 {
                 guard SyncBridgeService.isRunning() else { return }

--- a/ios/VaultSync/ViewModels/ObsidianReconnectFlow.swift
+++ b/ios/VaultSync/ViewModels/ObsidianReconnectFlow.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Sequencing core of the "reconnect the Obsidian folder" picker flow
+/// (issue #53). Reconnecting produces no `pendingFolders` change event, so
+/// the standing `onChange` trigger stays silent and existing pending shares
+/// sat untouched until an unrelated change event — this flow runs the accept
+/// pass explicitly after a successful grant.
+///
+/// The pass runs only AFTER the path reconcile has finished: an accept pass
+/// running concurrently would compute its occupied-path set from the
+/// pre-reconcile folder list — stale exactly when the user is repairing a
+/// container move, which is when this flow typically runs.
+///
+/// `reconcile` cannot fail by type (the manager's reconcile task never
+/// throws). If it never returns, the retry pass is deliberately NOT fired by
+/// a timeout — a timed retry would reintroduce the stale-occupied-set race
+/// this ordering exists to prevent; the standing `pendingFolders` change
+/// trigger remains in place and covers any later change event.
+///
+/// All effects are injected so the sequencing is unit-testable without
+/// SwiftUI, the filesystem, or the bridge.
+enum ObsidianReconnectFlow {
+    /// Runs the reconnect sequence. Returns the `grantAccess` error (the
+    /// sequence aborts, nothing else runs), or nil once the retry pass ran.
+    @MainActor
+    static func run(
+        grantAccess: @MainActor () -> String?,
+        onGrantSucceeded: @MainActor () -> Void,
+        reconcile: @MainActor () async -> Void,
+        retryPendingShares: @MainActor () -> Void
+    ) async -> String? {
+        if let error = grantAccess() {
+            return error
+        }
+        // Immediate UI feedback (failure reset, selection advisory) must not
+        // wait for the reconcile's engine round-trips.
+        onGrantSucceeded()
+        await reconcile()
+        retryPendingShares()
+        return nil
+    }
+}

--- a/ios/VaultSync/Views/ContentView.swift
+++ b/ios/VaultSync/Views/ContentView.swift
@@ -103,22 +103,40 @@ struct ContentView: View {
                 showObsidianPicker = false
             }) { url in
                 showObsidianPicker = false
-                if let err = vaultManager.grantAccess(url: url) {
-                    alertMessage = mappedError(err, fallbackTitle: L10n.tr("Obsidian Folder Connection Failed")).userVisibleDescription
-                    showAlert = true
-                } else {
-                    // Re-picking the Obsidian directory may resolve to a new
-                    // container path — rebase any mapped folders onto it so a
-                    // previously-unreachable vault reconnects.
-                    syncthingManager.reconcileFolderPaths(obsidianRoot: vaultManager.obsidianBasePath)
-                    // A share that had no safe location under the old root
-                    // (e.g. the root was itself a vault, #45 follow-up) may
-                    // succeed under the new one — let auto-accept try again.
-                    pendingShareFailures.removeAll()
-                    if let advisory = vaultManager.selectionAdvisory {
-                        infoMessage = advisory
-                        showInfoAlert = true
-                        vaultManager.clearSelectionAdvisory()
+                Task {
+                    if let err = await ObsidianReconnectFlow.run(
+                        grantAccess: { vaultManager.grantAccess(url: url) },
+                        onGrantSucceeded: {
+                            // A share that had no safe location under the old
+                            // root (e.g. the root was itself a vault, #45
+                            // follow-up) may succeed under the new one — clear
+                            // the failures so the retry pass attempts it.
+                            pendingShareFailures.removeAll()
+                            if let advisory = vaultManager.selectionAdvisory {
+                                infoMessage = advisory
+                                showInfoAlert = true
+                                vaultManager.clearSelectionAdvisory()
+                            }
+                        },
+                        reconcile: {
+                            // Re-picking the Obsidian directory may resolve to
+                            // a new container path — rebase any mapped folders
+                            // onto it so a previously-unreachable vault
+                            // reconnects.
+                            await syncthingManager.reconcileFolderPaths(
+                                obsidianRoot: vaultManager.obsidianBasePath
+                            ).value
+                        },
+                        retryPendingShares: {
+                            // Reconnecting produces no pendingFolders change
+                            // event, so the standing onChange trigger stays
+                            // silent — run the accept pass explicitly, on
+                            // settled paths (#53).
+                            autoAcceptPendingShares(syncthingManager.pendingFolders)
+                        }
+                    ) {
+                        alertMessage = mappedError(err, fallbackTitle: L10n.tr("Obsidian Folder Connection Failed")).userVisibleDescription
+                        showAlert = true
                     }
                 }
             }

--- a/ios/VaultSyncTests/ObsidianReconnectFlowTests.swift
+++ b/ios/VaultSyncTests/ObsidianReconnectFlowTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import VaultSync
+
+@MainActor
+@Suite("Auto-accept fires after Obsidian reconnect (#53)")
+struct ObsidianReconnectFlowTests {
+
+    @Test("Successful grant runs the full sequence in order: immediate feedback, reconcile, then the accept pass")
+    func successRunsFullSequenceInOrder() async {
+        var events: [String] = []
+
+        let error = await ObsidianReconnectFlow.run(
+            grantAccess: { events.append("grant"); return nil },
+            onGrantSucceeded: { events.append("feedback") },
+            reconcile: {
+                events.append("reconcile-start")
+                // Suspend at least once so an accept pass wrongly fired
+                // concurrently (instead of sequenced) would interleave here
+                // and break the order assertion below.
+                await Task.yield()
+                events.append("reconcile-end")
+            },
+            retryPendingShares: { events.append("retry") }
+        )
+
+        #expect(error == nil)
+        #expect(events == ["grant", "feedback", "reconcile-start", "reconcile-end", "retry"])
+    }
+
+    @Test("Failed grant short-circuits: no feedback, no reconcile, no accept pass")
+    func failedGrantShortCircuits() async {
+        var events: [String] = []
+
+        let error = await ObsidianReconnectFlow.run(
+            grantAccess: { events.append("grant"); return "no access" },
+            onGrantSucceeded: { events.append("feedback") },
+            reconcile: { events.append("reconcile") },
+            retryPendingShares: { events.append("retry") }
+        )
+
+        #expect(error == "no access")
+        #expect(events == ["grant"])
+    }
+
+    @Test("A reconcile that does not return fires no accept pass — no timeout fallback; the standing pendingFolders change trigger covers that case — and a late reconcile still completes the sequence")
+    func hangingReconcileFiresNoRetryUntilItReturns() async {
+        var retried = false
+        var releaseReconcile: CheckedContinuation<Void, Never>?
+
+        let flow = Task {
+            await ObsidianReconnectFlow.run(
+                grantAccess: { nil },
+                onGrantSucceeded: { },
+                reconcile: {
+                    await withCheckedContinuation { releaseReconcile = $0 }
+                },
+                retryPendingShares: { retried = true }
+            )
+        }
+
+        // Wait until the flow is suspended inside the reconcile, then give it
+        // ample opportunity to (wrongly) fire the retry while still pending.
+        while releaseReconcile == nil { await Task.yield() }
+        for _ in 0..<50 { await Task.yield() }
+        #expect(!retried)
+
+        // A reconcile that eventually returns still completes the sequence.
+        releaseReconcile?.resume()
+        let error = await flow.value
+        #expect(error == nil)
+        #expect(retried)
+    }
+}


### PR DESCRIPTION
Closes #53.

Auto-accept had a single trigger — onChange(of: pendingFolders) — but reconnecting the Obsidian folder changes no pendingFolders value, so a waiting share stayed pending until an unrelated change event, often an app restart. The picker's success path now runs the accept pass explicitly.

What could go wrong, and why this is safe: the pass is sequenced AFTER reconcileFolderPaths has finished (the method now returns its task; existing call sites discard it unchanged) — a concurrent pass would compute its occupied-path overlap set from pre-reconcile paths, stale exactly during a container-move repair. If the reconcile never returns, no timed retry fires; the standing onChange trigger keeps covering later events. Nothing becomes acceptable that was not already: same eligibility rules (doctrine 002/006 untouched), same overlap guards — one additional trigger point on an explicit user action.

Tests: new ObsidianReconnectFlow sequencing core (injected effects) with a 3-test regression suite — full order on success, short-circuit on failed grant, no retry while the reconcile is pending. Verified on Linux: design-token lint. Pending: macOS xcodebuild test pass (CI runs it).