### PR TITLE
fix(notify): sanitize operational logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to VaultSync are documented here.
 
 ### Privacy
 
+- **Server-helper logs now retain only operational categories** — `vaultsync-notify` no longer writes Syncthing Device IDs, folder IDs, local or Relay endpoint URLs, event markers, config paths, raw dependency errors, or HTTP response bodies to service logs. Fixed error categories, status codes, bounded counts, and durations preserve troubleshooting without exposing routing or filesystem context.
 - **Synchronization diagnostics no longer retain raw identifiers, paths, or server bodies** — check results and random check identifiers stay in memory and never reach Cloud Relay. Free-form Relay response bodies and legacy background error details are discarded or migrated to structured categories; app diagnostics log only generic states/counts, and unfiltered embedded Syncthing logging is disabled because upstream attributes can include file, folder, or peer values.
 - **Relay data handling is documented at the field level** — the Privacy Policy now lists the limited StoreKit verification and operational timestamps retained by Relay 1.2.0, and clarifies that the signed transaction is verified but not stored as a complete token.
 - **The Relay’s last-signal timestamp is documented honestly** — it is stored only to explain which wake-up step is pending, carries no file or vault metadata, does not authenticate the server helper, and is not proof of Apple delivery or completed synchronization. Deletion requests remove it with the other Relay data.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -64,12 +64,14 @@ their free-form detail is discarded and the legacy record is removed. This
 migration does not touch subscription state, provisioning, APNs registration,
 folder mappings, sync identities, or wake-up history.
 
-Application diagnostic logs contain only generic states, counts, durations, and
-error categories. Unfiltered embedded Syncthing logging is disabled because its
-upstream attributes can include file paths, folder IDs, or peer IDs. None of the
-local diagnostic values above is sent to Cloud Relay. Cloud Relay never receives
-a file name, folder or vault name, file or vault path, file content, or
-diagnostic check identifier.
+Application and `vaultsync-notify` operational logs contain only generic states,
+bounded counts, durations, status codes, and fixed error categories. The helper
+does not log Device IDs, folder IDs, event markers, endpoint URLs, configuration
+paths, Syncthing API keys, or raw request/response bodies. Unfiltered embedded
+Syncthing logging is disabled because its upstream attributes can include file
+paths, folder IDs, or peer IDs. None of the local diagnostic values above is sent
+to Cloud Relay. Cloud Relay never receives a file name, folder or vault name,
+file or vault path, file content, or diagnostic check identifier.
 
 ### Data Security
 

--- a/docs/relay-spec.md
+++ b/docs/relay-spec.md
@@ -255,6 +255,7 @@ The container reads its own Syncthing Device ID automatically from `/rest/system
 - The central relay receives and forwards an anonymous wake-up signal — it has no knowledge of what changed or where.
 - The central relay stores the last accepted v1 signal time per Device ID so the app can explain which wake-up leg is pending.
 - APNs payload is a silent push with no visible content (`content-available: 1`, no alert/body).
+- Helper operational logs contain only fixed categories, status codes, bounded counts, and durations; they omit Device/folder identifiers, paths and endpoint URLs, event markers, API keys, and raw request/response bodies.
 
 ### Token Storage
 

--- a/ios/scripts/sync-proof-privacy-lint.sh
+++ b/ios/scripts/sync-proof-privacy-lint.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHECK_CORE="$ROOT/ios/VaultSync/Services/RelaySyncPathCheck.swift"
 RELAY_SERVICE="$ROOT/ios/VaultSync/Services/RelayService.swift"
+NOTIFY_LOG_SOURCES=(
+  "$ROOT/notify/main.go"
+  "$ROOT/notify/doctor.go"
+  "$ROOT/notify/relay.go"
+  "$ROOT/notify/syncthing.go"
+)
 
 if rg -n \
   'UserDefaults|KeychainService|FileManager|Logger\(|RelayService|SubscriptionManager|RelayProvisionStatusStore|RelayTriggerStore|Bridge(Add|Remove|Set|Rescan)' \
@@ -31,5 +37,19 @@ fi
 
 rg -q 'slog\.SetDefault\(.*io\.Discard' "$ROOT/go/bridge/syncthing.go"
 rg -q 'log\.SetOutput\(io\.Discard' "$ROOT/go/bridge/syncthing.go"
+
+if rg -n -U \
+  'slog\.(Debug|Info|Warn|Error)\([^\n]*(\n[^\n]*){0,12}"(device_id|device|folder|marker|syncthing_url|relay_url|source|error|warning)"[[:space:]]*,' \
+  "${NOTIFY_LOG_SOURCES[@]}"; then
+  echo "❌ Notify logs contain a forbidden identifier, path, marker, or raw error field."
+  exit 1
+fi
+
+if rg -n \
+  'io\.ReadAll\([^\n]*resp\.Body|readBodySnippet|HTTPStatusError[^\n]*(URL|Body)' \
+  "$ROOT/notify/relay.go" "$ROOT/notify/syncthing.go" "$ROOT/notify/errors.go"; then
+  echo "❌ Notify dependency errors can retain a raw endpoint or response body."
+  exit 1
+fi
 
 echo "✅ Sync-proof privacy lint passed — passive core, structured diagnostics, sanitized logs."

--- a/notify/README.md
+++ b/notify/README.md
@@ -175,4 +175,8 @@ docker build -t vaultsync-notify .  # Docker image
 
 ## Privacy & license
 
-Only the Syncthing Device ID is sent to the relay, as a routing identifier. No file names, folder names, file sizes, or other metadata leave your server. Licensed [MPL-2.0](../LICENSE).
+Only the Syncthing Device ID is sent to the relay, as a routing identifier. No file names, folder names, file sizes, or other metadata leave your server.
+
+Operational logs contain fixed states, error categories, status codes, bounded counts, and durations. They do not contain Device IDs, folder IDs, event markers, local or Relay endpoint URLs, config paths, Syncthing API keys, or raw request/response bodies. The helper keeps the API key and watched-folder selection in process memory and does not create a separate credential store.
+
+Licensed [MPL-2.0](../LICENSE).

--- a/notify/doctor.go
+++ b/notify/doctor.go
@@ -215,7 +215,7 @@ func runPreflight(ctx context.Context, cfg Config, mode preflightMode) (int, err
 				case errors.Is(err, errNoRemoteDeviceConnected):
 					return fmt.Sprintf("none of the %d configured remote device(s) is currently connected — sync and wake-up delivery are idle until one connects. A device that is off or away is normal. Fix (if unexpected): open the Syncthing Web UI and check the device is resumed and online on both sides.", remoteCount), true
 				default:
-					return "could not evaluate (peer state never fails the doctor): " + err.Error(), true
+					return "could not evaluate peer state; the doctor keeps this as a warning. Check Syncthing API availability and retry.", true
 				}
 			},
 		}, preflightCheck{
@@ -260,7 +260,7 @@ func runPreflight(ctx context.Context, cfg Config, mode preflightMode) (int, err
 				if errors.Is(err, errNoFolderSharedConnected) {
 					return fmt.Sprintf("%d remote device(s) connected, but no folder is shared with any of them — changes on this server cannot reach them, so no wake-up will ever fire. Fix: open the Syncthing Web UI, folder -> Edit -> Sharing, tick the device, then accept the share on the other device.", connectedCount), true
 				}
-				return "could not evaluate (peer state never fails the doctor): " + err.Error(), true
+				return "could not evaluate folder sharing; the doctor keeps this as a warning. Check Syncthing API availability and retry.", true
 			},
 		})
 	}
@@ -279,7 +279,8 @@ func runPreflight(ctx context.Context, cfg Config, mode preflightMode) (int, err
 						"component", "preflight",
 						"mode", mode.Name,
 						"check", check.Name,
-						"warning", msg,
+						"result", "warn",
+						"error_kind", operationalErrorKind(err),
 					)
 					continue
 				}
@@ -344,7 +345,7 @@ func runCheckWithRetry(ctx context.Context, policy retryPolicy, checkName string
 			"component", "preflight",
 			"check", checkName,
 			"attempt", attempt,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"retry_in", backoff,
 		)
 
@@ -373,8 +374,8 @@ func logPreflightFailure(mode string, check preflightCheck, err error) {
 		"component", "preflight",
 		"mode", mode,
 		"check", check.Name,
-		"error", err,
-		"hint", check.Remediation,
+		"error_kind", operationalErrorKind(err),
+		"action", "follow_remediation",
 	)
 }
 
@@ -408,5 +409,5 @@ func hintForCheckFailure(err error) string {
 		return "Request was canceled."
 	}
 
-	return err.Error()
+	return "The dependency request failed. Follow the remediation below and retry."
 }

--- a/notify/errors.go
+++ b/notify/errors.go
@@ -1,21 +1,57 @@
 package main
 
-import "fmt"
+import (
+	"context"
+	"errors"
+	"fmt"
+)
 
 // HTTPStatusError indicates a non-200 response from an HTTP dependency.
 type HTTPStatusError struct {
 	Component  string
-	URL        string
 	StatusCode int
-	Body       string
 }
 
 func (e *HTTPStatusError) Error() string {
 	if e == nil {
 		return "http status error"
 	}
-	if e.Body == "" {
-		return fmt.Sprintf("%s returned HTTP %d for %s", e.Component, e.StatusCode, e.URL)
+	return fmt.Sprintf("%s returned HTTP %d", e.Component, e.StatusCode)
+}
+
+// operationalErrorKind converts arbitrary dependency errors into a bounded,
+// non-sensitive category for logs. The original error stays in memory for
+// control flow and user-invoked diagnostics, but identifiers, endpoint URLs,
+// paths, response bodies, and library-specific error strings never enter the
+// operational log stream.
+func operationalErrorKind(err error) string {
+	switch {
+	case err == nil:
+		return "none"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case isSubscriptionInactive(err):
+		return "subscription_inactive"
+	case isFatal(err):
+		return "configuration"
 	}
-	return fmt.Sprintf("%s returned HTTP %d for %s: %s", e.Component, e.StatusCode, e.URL, e.Body)
+
+	var statusErr *HTTPStatusError
+	if errors.As(err, &statusErr) {
+		return "http_status"
+	}
+
+	var rateLimited *rateLimitError
+	if errors.As(err, &rateLimited) {
+		return "rate_limited"
+	}
+
+	var transient *transientError
+	if errors.As(err, &transient) {
+		return "transport"
+	}
+
+	return "operation_failed"
 }

--- a/notify/errors.go
+++ b/notify/errors.go
@@ -4,7 +4,71 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 )
+
+type configurationError struct {
+	kind   string
+	action string
+	fields []string
+	cause  error
+}
+
+func newConfigurationError(kind, action string, cause error, fields ...string) error {
+	return &configurationError{
+		kind:   kind,
+		action: action,
+		fields: append([]string(nil), fields...),
+		cause:  cause,
+	}
+}
+
+func (e *configurationError) Error() string {
+	if e == nil || e.cause == nil {
+		return "invalid runtime configuration"
+	}
+	return e.cause.Error()
+}
+
+func (e *configurationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+var allowedOperationalConfigFields = map[string]bool{
+	"DEBOUNCE_SECONDS":        true,
+	"RELAY_URL":               true,
+	"STALE_RETRIGGER_SECONDS": true,
+	"STARTUP_ANNOUNCE":        true,
+	"SYNCTHING_API_KEY":       true,
+	"SYNCTHING_API_URL":       true,
+	"SYNCTHING_CONFIG":        true,
+}
+
+func configurationErrorFields(err error) string {
+	var configErr *configurationError
+	if !errors.As(err, &configErr) {
+		return ""
+	}
+
+	safe := make([]string, 0, len(configErr.fields))
+	for _, field := range configErr.fields {
+		if allowedOperationalConfigFields[field] {
+			safe = append(safe, field)
+		}
+	}
+	return strings.Join(safe, ",")
+}
+
+func configurationErrorAction(err error) string {
+	var configErr *configurationError
+	if !errors.As(err, &configErr) || configErr.action == "" {
+		return "exit"
+	}
+	return configErr.action
+}
 
 // HTTPStatusError indicates a non-200 response from an HTTP dependency.
 type HTTPStatusError struct {
@@ -25,6 +89,11 @@ func (e *HTTPStatusError) Error() string {
 // paths, response bodies, and library-specific error strings never enter the
 // operational log stream.
 func operationalErrorKind(err error) string {
+	var configErr *configurationError
+	if errors.As(err, &configErr) {
+		return "configuration_" + configErr.kind
+	}
+
 	switch {
 	case err == nil:
 		return "none"

--- a/notify/main.go
+++ b/notify/main.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -83,7 +82,7 @@ func main() {
 		slog.Error("invalid runtime configuration",
 			"classification", "fatal",
 			"component", "config",
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "exit",
 		)
 		os.Exit(1)
@@ -97,7 +96,7 @@ func main() {
 			slog.Error("doctor checks failed",
 				"classification", "fatal",
 				"component", "doctor",
-				"error", err,
+				"error_kind", operationalErrorKind(err),
 				"action", "fix_configuration",
 			)
 			os.Exit(1)
@@ -108,7 +107,7 @@ func main() {
 			slog.Error("healthcheck failed",
 				"classification", "fatal",
 				"component", "healthcheck",
-				"error", err,
+				"error_kind", operationalErrorKind(err),
 			)
 			os.Exit(1)
 		}
@@ -221,12 +220,11 @@ func loadConfig() (Config, error) {
 				filled = append(filled, "SYNCTHING_API_KEY")
 			}
 			if len(filled) > 0 {
-				// The API key itself is deliberately never logged.
+				// Values and the discovered config path are deliberately never
+				// logged; field names are sufficient for operational diagnosis.
 				slog.Info("auto-detected Syncthing configuration from config.xml",
 					"component", "config",
-					"source", detected.Source,
 					"filled", strings.Join(filled, ", "),
-					"syncthing_url", apiURL,
 				)
 			}
 		}
@@ -372,7 +370,7 @@ func runService(ctx context.Context, cfg Config) int {
 		slog.Error("failed to initialize Syncthing Device ID",
 			"classification", "fatal",
 			"component", "syncthing",
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "exit",
 		)
 		return 1
@@ -383,18 +381,16 @@ func runService(ctx context.Context, cfg Config) int {
 		slog.Error("relay startup check failed with fatal configuration error",
 			"classification", "fatal",
 			"component", "relay",
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "exit",
 		)
 		return 1
 	}
 
 	slog.Info("vaultsync-notify starting",
-		"device_id", deviceID,
-		"syncthing_url", cfg.SyncthingAPIURL,
-		"relay_url", cfg.RelayURL,
 		"debounce_seconds", cfg.DebounceSeconds,
-		"watched_folders", formatWatched(cfg.WatchedFolders),
+		"watched_folder_scope", watchedFolderScope(cfg.WatchedFolders),
+		"watched_folder_count", len(cfg.WatchedFolders),
 		"startup_announce", cfg.StartupAnnounce,
 		"stale_retrigger_seconds", cfg.StaleRetriggerSeconds,
 	)
@@ -475,19 +471,13 @@ func runService(ctx context.Context, cfg Config) int {
 
 			if lastTriggered[candidate.Folder] == candidate.Marker {
 				slog.Debug("skipping duplicate trigger candidate",
-					"type", ev.Type,
-					"folder", candidate.Folder,
-					"marker", candidate.Marker,
-					"id", ev.ID,
+					"event_type", ev.Type,
 				)
 				continue
 			}
 
 			slog.Debug("queued trigger candidate",
-				"type", ev.Type,
-				"folder", candidate.Folder,
-				"marker", candidate.Marker,
-				"id", ev.ID,
+				"event_type", ev.Type,
 			)
 			pending[candidate.Folder] = candidate.Marker
 
@@ -544,7 +534,7 @@ func runService(ctx context.Context, cfg Config) int {
 				slog.Warn("stale-peer sweep failed; retrying next interval",
 					"classification", "recoverable",
 					"component", "syncthing",
-					"error", err,
+					"error_kind", operationalErrorKind(err),
 					"action", "continue",
 				)
 				continue
@@ -621,9 +611,7 @@ func anyPeerNeedsData(ctx context.Context, st *SyncthingClient, selfID string, w
 				var statusErr *HTTPStatusError
 				if errors.As(err, &statusErr) {
 					slog.Debug("skipping completion check",
-						"device", dev.DeviceID,
-						"folder", folder,
-						"error", err,
+						"error_kind", operationalErrorKind(err),
 					)
 					continue
 				}
@@ -663,7 +651,7 @@ func waitForDeviceID(ctx context.Context, st *SyncthingClient) (string, error) {
 			"classification", "recoverable",
 			"component", "syncthing",
 			"attempt", attempt,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"retry_in", backoff,
 		)
 
@@ -696,7 +684,7 @@ func warmupRelay(ctx context.Context, relay *RelayClient) error {
 			slog.Warn("relay health check failed at startup; continuing with runtime retries",
 				"classification", "recoverable",
 				"component", "relay",
-				"error", err,
+				"error_kind", operationalErrorKind(err),
 				"action", "continue",
 			)
 			return nil
@@ -706,7 +694,7 @@ func warmupRelay(ctx context.Context, relay *RelayClient) error {
 			"classification", "recoverable",
 			"component", "relay",
 			"attempt", attempt,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"retry_in", backoff,
 		)
 
@@ -831,7 +819,7 @@ func fireTrigger(ctx context.Context, relay *RelayClient, reason string) trigger
 			"classification", "fatal",
 			"component", "relay",
 			"reason", reason,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "exit",
 		)
 		return outcomeFatal
@@ -840,7 +828,7 @@ func fireTrigger(ctx context.Context, relay *RelayClient, reason string) trigger
 			"classification", "recoverable",
 			"component", "relay",
 			"reason", reason,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "await_active_subscription",
 		)
 		return outcomeSubscriptionInactive
@@ -849,23 +837,18 @@ func fireTrigger(ctx context.Context, relay *RelayClient, reason string) trigger
 			"classification", "recoverable",
 			"component", "relay",
 			"reason", reason,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"action", "continue",
 		)
 		return outcomeRetry
 	}
 }
 
-func formatWatched(folders map[string]bool) string {
+func watchedFolderScope(folders map[string]bool) string {
 	if folders == nil {
 		return "all"
 	}
-	ids := make([]string, 0, len(folders))
-	for id := range folders {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-	return strings.Join(ids, ", ")
+	return "selected"
 }
 
 func isFatalRelayConfigError(err error) bool {

--- a/notify/main.go
+++ b/notify/main.go
@@ -79,12 +79,7 @@ func main() {
 
 	cfg, err := loadConfigAwaitingSyncthing(context.Background())
 	if err != nil {
-		slog.Error("invalid runtime configuration",
-			"classification", "fatal",
-			"component", "config",
-			"error_kind", operationalErrorKind(err),
-			"action", "exit",
-		)
+		logInvalidRuntimeConfiguration(err)
 		os.Exit(1)
 	}
 
@@ -118,6 +113,19 @@ func main() {
 		stop()
 		os.Exit(code)
 	}
+}
+
+func logInvalidRuntimeConfiguration(err error) {
+	attributes := []any{
+		"classification", "fatal",
+		"component", "config",
+		"error_kind", operationalErrorKind(err),
+	}
+	if fields := configurationErrorFields(err); fields != "" {
+		attributes = append(attributes, "fields", fields)
+	}
+	attributes = append(attributes, "action", configurationErrorAction(err))
+	slog.Error("invalid runtime configuration", attributes...)
 }
 
 func parseMode() (appMode, error) {
@@ -155,7 +163,12 @@ func loadConfig() (Config, error) {
 	if v := os.Getenv("DEBOUNCE_SECONDS"); v != "" {
 		d, err := strconv.Atoi(v)
 		if err != nil || d < 1 {
-			return Config{}, fmt.Errorf("DEBOUNCE_SECONDS must be a positive integer (got %q)", v)
+			return Config{}, newConfigurationError(
+				"invalid_value",
+				"correct_configuration_value",
+				fmt.Errorf("DEBOUNCE_SECONDS must be a positive integer (got %q)", v),
+				"DEBOUNCE_SECONDS",
+			)
 		}
 		debounce = d
 	}
@@ -165,7 +178,12 @@ func loadConfig() (Config, error) {
 	if v := os.Getenv("STALE_RETRIGGER_SECONDS"); v != "" {
 		s, err := strconv.Atoi(v)
 		if err != nil || s < 0 {
-			return Config{}, fmt.Errorf("STALE_RETRIGGER_SECONDS must be a non-negative integer (got %q)", v)
+			return Config{}, newConfigurationError(
+				"invalid_value",
+				"correct_configuration_value",
+				fmt.Errorf("STALE_RETRIGGER_SECONDS must be a non-negative integer (got %q)", v),
+				"STALE_RETRIGGER_SECONDS",
+			)
 		}
 		staleRetrigger = s
 	}
@@ -179,7 +197,12 @@ func loadConfig() (Config, error) {
 		case "1", "true", "yes", "on":
 			startupAnnounce = true
 		default:
-			return Config{}, fmt.Errorf("STARTUP_ANNOUNCE must be a boolean (got %q)", v)
+			return Config{}, newConfigurationError(
+				"invalid_value",
+				"correct_configuration_value",
+				fmt.Errorf("STARTUP_ANNOUNCE must be a boolean (got %q)", v),
+				"STARTUP_ANNOUNCE",
+			)
 		}
 	}
 
@@ -261,12 +284,36 @@ func loadConfig() (Config, error) {
 		// config.xml) than "set the env vars / SYNCTHING_CONFIG", so surface it
 		// directly instead of burying it in the generic message.
 		if detectErr != nil && errors.Is(detectErr, os.ErrPermission) {
-			return Config{}, detectErr
+			return Config{}, newConfigurationError(
+				"permission_denied",
+				"check_syncthing_config_permissions",
+				detectErr,
+				"SYNCTHING_CONFIG",
+			)
 		}
 		if detectErr != nil {
-			return Config{}, fmt.Errorf("missing %s; Syncthing auto-detection also found nothing: %w", strings.Join(missing, ", "), detectErr)
+			cause := fmt.Errorf("missing %s; Syncthing auto-detection also found nothing: %w", strings.Join(missing, ", "), detectErr)
+			if errors.Is(detectErr, errNoSyncthingConfig) {
+				return Config{}, newConfigurationError(
+					"missing",
+					"set_required_configuration",
+					cause,
+					missing...,
+				)
+			}
+			return Config{}, newConfigurationError(
+				"invalid_syncthing_config",
+				"check_syncthing_config",
+				cause,
+				"SYNCTHING_CONFIG",
+			)
 		}
-		return Config{}, fmt.Errorf("required configuration not set: %s. Set them explicitly; the Syncthing key/URL can also be auto-detected by pointing SYNCTHING_CONFIG at your config.xml", strings.Join(missing, ", "))
+		return Config{}, newConfigurationError(
+			"missing",
+			"set_required_configuration",
+			fmt.Errorf("required configuration not set: %s. Set them explicitly; the Syncthing key/URL can also be auto-detected by pointing SYNCTHING_CONFIG at your config.xml", strings.Join(missing, ", ")),
+			missing...,
+		)
 	}
 	return cfg, nil
 }

--- a/notify/main_test.go
+++ b/notify/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -824,6 +825,11 @@ func TestRunServiceStartupAnnounceDisabled(t *testing.T) {
 // best-effort: an inactive-subscription verdict (HTTP 400) at startup is logged
 // and ignored — the service keeps running and shuts down cleanly, never exit 1.
 func TestRunServiceStartupAnnounceInactiveKeepsRunning(t *testing.T) {
+	var logOutput bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
 	syncthing := newQuietSyncthingStub(t)
 
 	declined := make(chan struct{}, 1)
@@ -881,6 +887,26 @@ func TestRunServiceStartupAnnounceInactiveKeepsRunning(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("runService did not shut down after context cancel")
+	}
+
+	logs := logOutput.String()
+	for _, forbidden := range []string{
+		"DEVICE-QUIET",
+		syncthing.URL,
+		relay.URL,
+		"subscription expired",
+	} {
+		if strings.Contains(logs, forbidden) {
+			t.Fatalf("operational logs contain sensitive sentinel %q:\n%s", forbidden, logs)
+		}
+	}
+	for _, required := range []string{
+		"error_kind=subscription_inactive",
+		"watched_folder_scope=all",
+	} {
+		if !strings.Contains(logs, required) {
+			t.Fatalf("operational logs are missing safe field %q:\n%s", required, logs)
+		}
 	}
 }
 

--- a/notify/main_test.go
+++ b/notify/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -41,6 +42,73 @@ func TestLoadConfigRequiresBootstrapEnvironment(t *testing.T) {
 	for _, required := range []string{"SYNCTHING_API_URL", "SYNCTHING_API_KEY", "RELAY_URL"} {
 		if !strings.Contains(msg, required) {
 			t.Fatalf("error %q should mention missing %s", msg, required)
+		}
+	}
+}
+
+func TestPR100ConfigFailureLoggingStaysActionableAndPrivate(t *testing.T) {
+	t.Setenv("SYNCTHING_API_URL", "")
+	t.Setenv("SYNCTHING_API_KEY", "")
+	t.Setenv("RELAY_URL", "")
+	t.Setenv("DEBOUNCE_SECONDS", "")
+	t.Setenv("WATCHED_FOLDERS", "")
+
+	missingConfig := filepath.Join(t.TempDir(), "PRIVATE-CONFIG-PATH-SENTINEL.xml")
+	restore := syncthingConfigCandidatesFn
+	syncthingConfigCandidatesFn = func() []string { return []string{missingConfig} }
+	t.Cleanup(func() { syncthingConfigCandidatesFn = restore })
+
+	_, err := loadConfig()
+	if err == nil {
+		t.Fatal("expected configuration error when required values are unavailable")
+	}
+	if got := operationalErrorKind(err); got != "configuration_missing" {
+		t.Fatalf("operationalErrorKind() = %q, want actionable privacy-safe category", got)
+	}
+
+	var logOutput bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	logInvalidRuntimeConfiguration(err)
+
+	logs := logOutput.String()
+	if strings.Contains(logs, missingConfig) {
+		t.Fatalf("configuration log contains the probed config path: %s", logs)
+	}
+	for _, required := range []string{
+		"error_kind=configuration_missing",
+		"fields=SYNCTHING_API_URL,SYNCTHING_API_KEY,RELAY_URL",
+		"action=set_required_configuration",
+	} {
+		if !strings.Contains(logs, required) {
+			t.Fatalf("configuration log is missing safe operator detail %q: %s", required, logs)
+		}
+	}
+
+	const secretValue = "PRIVATE-CONFIG-VALUE-SENTINEL"
+	invalidErr := newConfigurationError(
+		"invalid_value",
+		"correct_configuration_value",
+		fmt.Errorf("invalid value %s at /private/config/path", secretValue),
+		"DEBOUNCE_SECONDS",
+		secretValue,
+	)
+	logOutput.Reset()
+	logInvalidRuntimeConfiguration(invalidErr)
+	logs = logOutput.String()
+	for _, forbidden := range []string{secretValue, "/private/config/path"} {
+		if strings.Contains(logs, forbidden) {
+			t.Fatalf("configuration log contains sensitive sentinel %q: %s", forbidden, logs)
+		}
+	}
+	for _, required := range []string{
+		"error_kind=configuration_invalid_value",
+		"fields=DEBOUNCE_SECONDS",
+		"action=correct_configuration_value",
+	} {
+		if !strings.Contains(logs, required) {
+			t.Fatalf("configuration log is missing safe invalid-value detail %q: %s", required, logs)
 		}
 	}
 }

--- a/notify/relay.go
+++ b/notify/relay.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -58,12 +57,9 @@ func (c *RelayClient) CheckHealth(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return &HTTPStatusError{
 			Component:  "relay",
-			URL:        url,
 			StatusCode: resp.StatusCode,
-			Body:       string(body),
 		}
 	}
 
@@ -127,7 +123,7 @@ func (c *RelayClient) Trigger(ctx context.Context) error {
 			"classification", "recoverable",
 			"component", "relay",
 			"attempt", attempt+1,
-			"error", err,
+			"error_kind", operationalErrorKind(err),
 			"retry_in", wait,
 		)
 
@@ -185,7 +181,7 @@ func (c *RelayClient) doTrigger(ctx context.Context, url string, body []byte) er
 	case http.StatusAccepted:
 		var tr triggerResponse
 		if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
-			slog.Warn("decode trigger response failed", "error", err)
+			slog.Warn("decode trigger response failed", "error_kind", "decode")
 			return nil // push was accepted, decode failure is non-critical
 		}
 		slog.Info("relay trigger accepted", "devices_notified", tr.DevicesNotified)
@@ -208,22 +204,15 @@ func (c *RelayClient) doTrigger(ctx context.Context, url string, body []byte) er
 		// cancelled, or not yet provisioned — the relay gates pushes on the
 		// verified StoreKit expiry. That is a self-resolving runtime state, not
 		// a misconfiguration — never fatal.
-		body := strings.TrimSpace(string(readBodySnippet(resp.Body)))
-		return &subscriptionInactiveError{statusCode: resp.StatusCode, body: body}
+		return &subscriptionInactiveError{statusCode: resp.StatusCode}
 
 	default:
 		// Any other status (5xx, or an undocumented 4xx such as a proxy-level
 		// 405/422) is treated as transient: keep retrying and stay alive rather
-		// than crash, and log the raw code honestly instead of guessing it is a
-		// subscription issue.
-		body := strings.TrimSpace(string(readBodySnippet(resp.Body)))
-		return &transientError{err: fmt.Errorf("unexpected status %d: %s", resp.StatusCode, body)}
+		// than crash. Preserve only the status code; dependency response bodies
+		// are untrusted and must not reach errors or logs.
+		return &transientError{err: fmt.Errorf("unexpected HTTP status %d", resp.StatusCode)}
 	}
-}
-
-func readBodySnippet(r io.Reader) []byte {
-	snippet, _ := io.ReadAll(io.LimitReader(r, 512))
-	return snippet
 }
 
 type fatalError struct{ msg string }
@@ -232,7 +221,8 @@ func (e *fatalError) Error() string { return e.msg }
 
 type transientError struct{ err error }
 
-func (e *transientError) Error() string { return e.err.Error() }
+func (e *transientError) Error() string { return "transient dependency failure" }
+func (e *transientError) Unwrap() error { return e.err }
 
 type rateLimitError struct{ retryAfter time.Duration }
 
@@ -247,14 +237,10 @@ func (e *rateLimitError) Error() string {
 // subscription is active again.
 type subscriptionInactiveError struct {
 	statusCode int
-	body       string
 }
 
 func (e *subscriptionInactiveError) Error() string {
-	if e.body == "" {
-		return fmt.Sprintf("relay declined trigger (HTTP %d): no active subscription for this device (expired, cancelled, or not yet provisioned)", e.statusCode)
-	}
-	return fmt.Sprintf("relay declined trigger (HTTP %d): no active subscription for this device (expired, cancelled, or not yet provisioned): %s", e.statusCode, e.body)
+	return fmt.Sprintf("relay declined trigger (HTTP %d): no active subscription for this device (expired, cancelled, or not yet provisioned)", e.statusCode)
 }
 
 func isFatal(err error) bool {

--- a/notify/relay_test.go
+++ b/notify/relay_test.go
@@ -4,10 +4,32 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+func TestDependencyErrorsDiscardURLsAndResponseBodies(t *testing.T) {
+	t.Parallel()
+
+	const responseSentinel = "SECRET-RESPONSE-BODY"
+	stub := newTriggerStub(t, http.StatusInternalServerError, "", responseSentinel)
+	err := stub.client().doTrigger(context.Background(), stub.triggerURL(), nil)
+	if err == nil {
+		t.Fatal("expected a transient error")
+	}
+	for _, forbidden := range []string{responseSentinel, stub.server.URL} {
+		if strings.Contains(err.Error(), forbidden) {
+			t.Fatalf("error contains sensitive sentinel %q: %v", forbidden, err)
+		}
+	}
+
+	statusErr := &HTTPStatusError{Component: "relay", StatusCode: http.StatusBadGateway}
+	if got := statusErr.Error(); got != "relay returned HTTP 502" {
+		t.Fatalf("HTTPStatusError.Error() = %q, want status-only message", got)
+	}
+}
 
 // triggerStub is a relay test double that returns a fixed status for
 // POST /api/v1/trigger and counts how many times it was hit.

--- a/notify/syncthing.go
+++ b/notify/syncthing.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -66,12 +65,12 @@ func (c *SyncthingClient) Subscribe(ctx context.Context) <-chan Event {
 					slog.Error("syncthing event poll failed with fatal configuration error",
 						"classification", "fatal",
 						"component", "syncthing",
-						"error", err,
+						"error_kind", operationalErrorKind(err),
 						"action", "exit",
 					)
 					return
 				}
-				slog.Warn("syncthing event poll failed", "error", err, "retry_in", backoff)
+				slog.Warn("syncthing event poll failed", "error_kind", operationalErrorKind(err), "retry_in", backoff)
 				select {
 				case <-time.After(backoff):
 				case <-ctx.Done():
@@ -158,12 +157,9 @@ func (c *SyncthingClient) getSystemStatus(ctx context.Context, withAPIKey bool) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return systemStatus{}, resp.StatusCode, &HTTPStatusError{
 			Component:  "syncthing",
-			URL:        url,
 			StatusCode: resp.StatusCode,
-			Body:       string(body),
 		}
 	}
 
@@ -265,12 +261,9 @@ func (c *SyncthingClient) getJSON(ctx context.Context, url string, out any) erro
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return &HTTPStatusError{
 			Component:  "syncthing",
-			URL:        url,
 			StatusCode: resp.StatusCode,
-			Body:       string(body),
 		}
 	}
 
@@ -296,12 +289,9 @@ func (c *SyncthingClient) poll(ctx context.Context, since int) ([]Event, error) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return nil, &HTTPStatusError{
 			Component:  "syncthing",
-			URL:        url,
 			StatusCode: resp.StatusCode,
-			Body:       string(body),
 		}
 	}
 


### PR DESCRIPTION
This removes Syncthing Device IDs, local and Relay endpoint URLs, folder identifiers and event markers, config paths, raw dependency errors, and HTTP response bodies from `vaultsync-notify` operational logs. The helper now emits fixed error categories, bounded counts, status codes, and durations while retaining the original in-memory errors for control flow and privacy-safe doctor remediation.

HTTP dependency errors no longer retain URLs or response bodies, and the Privacy Policy, helper documentation, Relay specification, changelog, and sync-proof privacy lint describe and enforce the boundary. Regression coverage reproduces the previously leaking inactive-subscription startup path with Device-ID, URL, and body sentinels.

Trigger v1 requests, event selection, debounce behavior, configuration, persisted state, and Cloud Relay payloads are unchanged. The branch passed the complete Notify Go suite, `go vet`, `gofmt`, ShellCheck 0.10.0, the sync-proof privacy lint, `govulncheck`, and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Hardened `vaultsync-notify` operational logging by replacing sensitive details and raw errors with fixed categories, status codes, bounded counts, scopes, and durations.
- Removed URLs, Syncthing device and folder identifiers, event markers, configuration paths, API keys, and raw HTTP response bodies from errors and logs.
- Preserved trigger behavior, event selection, debounce logic, configuration, persisted state, and Cloud Relay payloads.
- Improved inactive-subscription startup coverage while ensuring the service remains running and logs only privacy-safe diagnostics.
- Updated privacy documentation, Relay specification, changelog, README, and privacy lint rules.

## Verification

Notify Go tests, `go vet`, `gofmt`, ShellCheck, privacy lint, `govulncheck`, and `git diff --check` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->