### PR TITLE
feat(notify): add dormant diagnostics capability foundation

### DIFF
--- a/notify/diagnostics_capabilities.go
+++ b/notify/diagnostics_capabilities.go
@@ -1,0 +1,116 @@
+package main
+
+const (
+	diagnosticsPairingCapabilityID   = "eu.vaultsync.diagnostics.helper-pairing/1"
+	diagnosticsNamespaceCapabilityID = "eu.vaultsync.diagnostics.namespace/1"
+	diagnosticsRoundtripCapabilityID = "eu.vaultsync.diagnostics.correlated-roundtrip/1"
+
+	diagnosticsProtocolMajor         = uint64(1)
+	diagnosticsCryptographicSuite    = uint64(1)
+	diagnosticsRoundtripRequiredBits = uint64(0x0f)
+)
+
+// diagnosticsCapabilityDisposition is deliberately limited to the two honest
+// pre-activation outcomes. M2 has no ready/available state and no transition
+// that can enable one.
+type diagnosticsCapabilityDisposition uint8
+
+const (
+	diagnosticsCapabilityUnavailable diagnosticsCapabilityDisposition = iota
+	diagnosticsCapabilityUnsupported
+)
+
+// diagnosticsCapabilityReason is a bounded local category. It never contains
+// a requested identifier, key, binding, path, nonce, digest, or body.
+type diagnosticsCapabilityReason uint8
+
+const (
+	diagnosticsCapabilityHelperMissing diagnosticsCapabilityReason = iota
+	diagnosticsCapabilityDisabled
+	diagnosticsCapabilityUnknown
+)
+
+type diagnosticsCapabilityDescriptor struct {
+	identifier    string
+	protocolMajor uint64
+	suite         uint64
+	requiredFlags uint64
+}
+
+type diagnosticsCapabilityStatus struct {
+	disposition diagnosticsCapabilityDisposition
+	reason      diagnosticsCapabilityReason
+	descriptor  diagnosticsCapabilityDescriptor
+}
+
+// diagnosticsCapabilityFoundation is a side-effect-free catalog. Its zero
+// value models a legacy helper with no capability foundation. The constructor
+// models a new helper that knows the approved contracts but keeps every one of
+// them disabled. There is intentionally no mutator or activation method.
+type diagnosticsCapabilityFoundation struct {
+	descriptors [3]diagnosticsCapabilityDescriptor
+}
+
+func newDormantDiagnosticsCapabilityFoundation() diagnosticsCapabilityFoundation {
+	return diagnosticsCapabilityFoundation{descriptors: [3]diagnosticsCapabilityDescriptor{
+		{
+			identifier:    diagnosticsPairingCapabilityID,
+			protocolMajor: diagnosticsProtocolMajor,
+			suite:         diagnosticsCryptographicSuite,
+		},
+		{
+			identifier:    diagnosticsNamespaceCapabilityID,
+			protocolMajor: diagnosticsProtocolMajor,
+			suite:         diagnosticsCryptographicSuite,
+		},
+		{
+			identifier:    diagnosticsRoundtripCapabilityID,
+			protocolMajor: diagnosticsProtocolMajor,
+			suite:         diagnosticsCryptographicSuite,
+			requiredFlags: diagnosticsRoundtripRequiredBits,
+		},
+	}}
+}
+
+// status is local model evaluation only. No runtime path currently calls it,
+// advertises it, serializes it, logs it, or exposes it over a listener.
+func (foundation diagnosticsCapabilityFoundation) status(identifier string) diagnosticsCapabilityStatus {
+	for _, descriptor := range foundation.descriptors {
+		if descriptor.identifier != "" && descriptor.identifier == identifier {
+			return diagnosticsCapabilityStatus{
+				disposition: diagnosticsCapabilityUnavailable,
+				reason:      diagnosticsCapabilityDisabled,
+				descriptor:  descriptor,
+			}
+		}
+	}
+
+	if isKnownDiagnosticsCapabilityIdentifier(identifier) {
+		return diagnosticsCapabilityStatus{
+			disposition: diagnosticsCapabilityUnavailable,
+			reason:      diagnosticsCapabilityHelperMissing,
+		}
+	}
+
+	return diagnosticsCapabilityStatus{
+		disposition: diagnosticsCapabilityUnsupported,
+		reason:      diagnosticsCapabilityUnknown,
+	}
+}
+
+// catalog returns a value copy so callers cannot mutate the dormant runtime
+// catalog through an alias.
+func (foundation diagnosticsCapabilityFoundation) catalog() [3]diagnosticsCapabilityDescriptor {
+	return foundation.descriptors
+}
+
+func isKnownDiagnosticsCapabilityIdentifier(identifier string) bool {
+	switch identifier {
+	case diagnosticsPairingCapabilityID,
+		diagnosticsNamespaceCapabilityID,
+		diagnosticsRoundtripCapabilityID:
+		return true
+	default:
+		return false
+	}
+}

--- a/notify/diagnostics_capabilities_test.go
+++ b/notify/diagnostics_capabilities_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiagnosticsCapabilityCatalogIsExactAndDormant(t *testing.T) {
+	fixture := loadDiagnosticsContractFixture(t)
+	foundation := newDormantDiagnosticsCapabilityFoundation()
+	catalog := foundation.catalog()
+
+	expectedFlags := map[string]uint64{
+		fixture.Capabilities["pairing"]:   0,
+		fixture.Capabilities["namespace"]: 0,
+		fixture.Capabilities["roundtrip"]: diagnosticsRoundtripRequiredBits,
+	}
+	if len(catalog) != len(expectedFlags) {
+		t.Fatalf("catalog size = %d, want %d", len(catalog), len(expectedFlags))
+	}
+
+	seen := make(map[string]bool, len(catalog))
+	for _, descriptor := range catalog {
+		wantFlags, ok := expectedFlags[descriptor.identifier]
+		if !ok {
+			t.Fatalf("unexpected diagnostics capability %q", descriptor.identifier)
+		}
+		if seen[descriptor.identifier] {
+			t.Fatalf("duplicate diagnostics capability %q", descriptor.identifier)
+		}
+		seen[descriptor.identifier] = true
+		if descriptor.protocolMajor != diagnosticsProtocolMajor || descriptor.suite != diagnosticsCryptographicSuite {
+			t.Fatalf("capability %q version/suite = %d/%d, want %d/%d", descriptor.identifier, descriptor.protocolMajor, descriptor.suite, diagnosticsProtocolMajor, diagnosticsCryptographicSuite)
+		}
+		if descriptor.requiredFlags != wantFlags {
+			t.Fatalf("capability %q flags = %#x, want %#x", descriptor.identifier, descriptor.requiredFlags, wantFlags)
+		}
+
+		status := foundation.status(descriptor.identifier)
+		if status.disposition != diagnosticsCapabilityUnavailable || status.reason != diagnosticsCapabilityDisabled {
+			t.Fatalf("capability %q is not dormant: %+v", descriptor.identifier, status)
+		}
+		if status.descriptor != descriptor {
+			t.Fatalf("capability %q status descriptor changed", descriptor.identifier)
+		}
+	}
+}
+
+func TestDiagnosticsCapabilityZeroValueUpgradeAndDowngradeStayUnavailable(t *testing.T) {
+	var legacy diagnosticsCapabilityFoundation
+	upgraded := newDormantDiagnosticsCapabilityFoundation()
+	var downgraded diagnosticsCapabilityFoundation
+
+	for _, identifier := range []string{
+		diagnosticsPairingCapabilityID,
+		diagnosticsNamespaceCapabilityID,
+		diagnosticsRoundtripCapabilityID,
+	} {
+		before := legacy.status(identifier)
+		afterUpgrade := upgraded.status(identifier)
+		afterDowngrade := downgraded.status(identifier)
+
+		if before.disposition != diagnosticsCapabilityUnavailable || before.reason != diagnosticsCapabilityHelperMissing {
+			t.Fatalf("legacy helper status for %q = %+v", identifier, before)
+		}
+		if afterUpgrade.disposition != diagnosticsCapabilityUnavailable || afterUpgrade.reason != diagnosticsCapabilityDisabled {
+			t.Fatalf("upgraded helper status for %q = %+v", identifier, afterUpgrade)
+		}
+		if afterDowngrade != before {
+			t.Fatalf("downgrade status for %q = %+v, want legacy %+v", identifier, afterDowngrade, before)
+		}
+	}
+}
+
+func TestDiagnosticsCapabilityUnknownInputIsUnsupportedAndNotReflected(t *testing.T) {
+	const sentinel = "SENTINEL-PRIVATE-CAPABILITY-INPUT/2"
+	status := newDormantDiagnosticsCapabilityFoundation().status(sentinel)
+	if status.disposition != diagnosticsCapabilityUnsupported || status.reason != diagnosticsCapabilityUnknown {
+		t.Fatalf("unknown capability status = %+v", status)
+	}
+	if status.descriptor != (diagnosticsCapabilityDescriptor{}) {
+		t.Fatalf("unknown capability must not acquire a descriptor: %+v", status.descriptor)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", status), sentinel) {
+		t.Fatal("unknown capability input was reflected into local status")
+	}
+}
+
+func TestLoadConfigInstallsOnlyDormantDiagnosticsCapabilities(t *testing.T) {
+	t.Setenv("SYNCTHING_API_URL", "http://localhost:8384")
+	t.Setenv("SYNCTHING_API_KEY", "test-key")
+	t.Setenv("RELAY_URL", "https://relay.example.com")
+	t.Setenv("DEBOUNCE_SECONDS", "")
+	t.Setenv("WATCHED_FOLDERS", "")
+	t.Setenv("STARTUP_ANNOUNCE", "false")
+	t.Setenv("STALE_RETRIGGER_SECONDS", "0")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig returned unexpected error: %v", err)
+	}
+	for _, descriptor := range cfg.diagnosticsCapabilities.catalog() {
+		status := cfg.diagnosticsCapabilities.status(descriptor.identifier)
+		if status.disposition != diagnosticsCapabilityUnavailable || status.reason != diagnosticsCapabilityDisabled {
+			t.Fatalf("loaded capability %q is not dormant: %+v", descriptor.identifier, status)
+		}
+	}
+}
+
+func TestDiagnosticsCapabilityRuntimeFileHasNoActivationSurface(t *testing.T) {
+	notifyRoot := filepath.Join(diagnosticsTestRepoRoot(t), "notify")
+	path := filepath.Join(notifyRoot, "diagnostics_capabilities.go")
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse runtime capability foundation: %v", err)
+	}
+	if len(file.Imports) != 0 {
+		t.Fatalf("dormant capability foundation must not import filesystem, network, logging, encoding, or persistence packages: %v", file.Imports)
+	}
+
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		name := strings.ToLower(function.Name.Name)
+		for _, forbidden := range []string{
+			"activate",
+			"enable",
+			"listen",
+			"serve",
+			"pair",
+			"persist",
+			"probe",
+			"write",
+		} {
+			if strings.Contains(name, forbidden) {
+				t.Fatalf("dormant capability foundation exposes activating function %q", function.Name.Name)
+			}
+		}
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read runtime capability foundation: %v", err)
+	}
+	for _, forbidden := range []string{
+		"http://",
+		"https://",
+		"/api/",
+		"VAULTSYNC_",
+		"SYNCTHING_",
+		"RELAY_",
+	} {
+		if strings.Contains(string(body), forbidden) {
+			t.Fatalf("dormant capability foundation contains operational carrier %q", forbidden)
+		}
+	}
+
+	mainBody, err := os.ReadFile(filepath.Join(notifyRoot, "main.go"))
+	if err != nil {
+		t.Fatalf("read helper entrypoint: %v", err)
+	}
+	// One declaration plus one dormant constructor assignment. Any third use
+	// means a runtime path started consulting the catalog and needs a later
+	// milestone's explicit review.
+	if got := strings.Count(string(mainBody), "diagnosticsCapabilities"); got != 2 {
+		t.Fatalf("helper entrypoint references diagnostics capabilities %d times, want exactly dormant declaration and construction", got)
+	}
+}

--- a/notify/diagnostics_contract_model_test.go
+++ b/notify/diagnostics_contract_model_test.go
@@ -281,9 +281,10 @@ func TestDiagnosticsTriggerV1WireRemainsExact(t *testing.T) {
 	}
 }
 
-func TestDiagnosticsFoundationHasNoRuntimeCarrier(t *testing.T) {
+func TestDiagnosticsFoundationHasNoOperationalRuntimeCarrier(t *testing.T) {
 	fixture := loadDiagnosticsContractFixture(t)
 	repoRoot := diagnosticsTestRepoRoot(t)
+	dormantCapabilityCarrier := filepath.Join(repoRoot, "notify", "diagnostics_capabilities.go")
 	runtimeRoots := []string{
 		filepath.Join(repoRoot, "notify"),
 		filepath.Join(repoRoot, "ios", "VaultSync"),
@@ -305,7 +306,7 @@ func TestDiagnosticsFoundationHasNoRuntimeCarrier(t *testing.T) {
 				return err
 			}
 			for name, capability := range fixture.Capabilities {
-				if bytes.Contains(body, []byte(capability)) {
+				if bytes.Contains(body, []byte(capability)) && path != dormantCapabilityCarrier {
 					return fmt.Errorf("runtime file %s contains dormant M1 capability %s", path, name)
 				}
 			}

--- a/notify/main.go
+++ b/notify/main.go
@@ -39,6 +39,11 @@ type Config struct {
 	// sweep. NOTE: like StartupAnnounce, the zero value keeps the feature off
 	// for focused Config-literal tests; only loadConfig applies the default.
 	StaleRetriggerSeconds int
+	// This internal field is a side-effect-free catalog. The
+	// real configuration loader installs only its dormant form; Config's zero
+	// value models a legacy helper. There is no environment switch or runtime
+	// path that can enable, advertise, persist, or call these capabilities.
+	diagnosticsCapabilities diagnosticsCapabilityFoundation
 }
 
 type appMode int
@@ -260,13 +265,14 @@ func loadConfig() (Config, error) {
 	// the app's setup command both supply it explicitly, so this costs the
 	// operator nothing in practice; only the Syncthing key/URL are auto-detected.
 	cfg := Config{
-		SyncthingAPIURL:       apiURL,
-		SyncthingAPIKey:       apiKey,
-		RelayURL:              required("RELAY_URL"),
-		DebounceSeconds:       debounce,
-		WatchedFolders:        watched,
-		StartupAnnounce:       startupAnnounce,
-		StaleRetriggerSeconds: staleRetrigger,
+		SyncthingAPIURL:         apiURL,
+		SyncthingAPIKey:         apiKey,
+		RelayURL:                required("RELAY_URL"),
+		DebounceSeconds:         debounce,
+		WatchedFolders:          watched,
+		StartupAnnounce:         startupAnnounce,
+		StaleRetriggerSeconds:   staleRetrigger,
+		diagnosticsCapabilities: newDormantDiagnosticsCapabilityFoundation(),
 	}
 
 	missing := make([]string, 0, 3)


### PR DESCRIPTION
## What & why

Adds the M2 dormant helper foundation after merged M1. The Notify helper now compiles the three approved Decision 022-024 capability descriptors into an internal value-only catalog, but has no available/ready state and no activation transition.

The real configuration loader constructs only the dormant catalog. Existing zero-value Config literals continue to model a legacy helper. No app or external caller can currently reach, query, advertise, enable, or use this catalog.

## Component(s)

- [ ] go (bridge / Syncthing)
- [ ] ios
- [x] notify
- [ ] docs / CI

## Dormant boundary

- Known capability on a new helper: local `unavailable/disabled`.
- Known capability on a legacy zero-value helper: local `unavailable/helper-missing`.
- Unknown capability/version: local `unsupported/unknown`, without reflecting the input.
- The runtime foundation has no imports and therefore no filesystem, network, listener, logging, encoding, credential, or persistence access.
- `main.go` contains exactly the private field declaration and dormant constructor assignment; no runtime path evaluates the catalog.
- There is no environment option, flag, listener, endpoint, pairing action, namespace action, probe, Syncthing mutation, Relay call, timer, background loop, or product UI.
- Trigger v1 and Cloud Relay v1 request bytes and behavior are unchanged.

## Exact catalog

- `eu.vaultsync.diagnostics.helper-pairing/1`, protocol 1, suite 1.
- `eu.vaultsync.diagnostics.namespace/1`, protocol 1, suite 1.
- `eu.vaultsync.diagnostics.correlated-roundtrip/1`, protocol 1, suite 1, required flags `0x0f`.
- Catalog access returns value copies; there is no mutable alias and no available state.

## Testing

- [x] `cd notify && go test ./... -count=1` — passed
- [x] `cd notify && go vet ./...` — passed
- [x] `cd notify && go test -race ./... -count=1` — passed
- [x] `cd notify && go test -run '^$' -fuzz=FuzzDiagnosticsContractCanonicalCBOR -fuzztime=10s` — passed, 312,872 executions
- [x] `gofmt -l .` — empty
- [x] `git diff --check` — passed
- [x] `notify/scripts/tests/install-dry-run-test.sh` — passed without privileged or mutating commands
- [x] native Notify build — passed
- [x] Linux amd64, Darwin arm64, and Windows amd64 cross-builds — passed
- [x] `govulncheck v1.6.0 ./...` — no vulnerabilities
- [x] GitHub Actions PR checks — passed on exact head `b4c8435c1e749a9a2d4ddccec6e805644ef28a52`
- [ ] Independent human review — not claimed

No signing, archive, production service, StoreKit, APNs, Trigger, status, probe, Relay, deployment, packaging publication, helper release, or rollout operation was performed.

## Existing-user and compatibility impact

- Existing app × existing helper: unchanged Trigger v1 and passive/local evidence.
- Existing app × new dormant helper: unchanged Trigger v1; catalog is unreachable and dormant.
- Future capable test client × existing helper: capability unavailable; no fallback, artifact, namespace, probe, or v1 change.
- Future capable test client × new dormant helper: capability unavailable/disabled; no pairing or enablement path exists.
- App downgrade: no helper behavior change and no state to clean.
- Helper downgrade: catalog disappears and remains capability unavailable; Trigger v1 stays wire-compatible.
- Re-upgrade: returns to dormant disabled state; no operation can resume.

## Security, privacy, migration, and rollback

- No credentials, keys, bindings, paths, Device IDs, folder IDs, nonces, hashes, signatures, bodies, or user data are added to logs or persistence.
- Unknown inputs are reduced to a fixed bounded category and never echoed.
- No state directory, namespace, file, ACL, mount, installer mutation, schema, or migration exists.
- Repository rollback is a revert of the two M2 commits.
- Binary downgrade to the prior helper removes only the dormant catalog; no data or credential rollback is required.
- The R0 Relay CI branch and Relay privacy PR remain separate and untouched.

## Release gate

VaultSync 2.0 remains **NO-GO**. The strongest implemented proof remains a fresh successful local file `ItemFinished` apply after cursor, RFC3339-nanosecond time, and stable engine-generation baselines. Upload is not implemented or confirmed. Controlled download is not implemented or confirmed. Roundtrip is not implemented or confirmed. Authenticated correlation is not implemented. Helper-first rollout and rollback remain unproven.

Owner approval is required before merge.