### PR TITLE
fix: use supported Dependabot Actions cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,12 +37,11 @@ updates:
       actions-major:
         patterns: ["*"]
         update-types: ["major"]
-    # Let a tag age before adopting it; bad action releases are usually
-    # yanked/fixed within a day or two.
+    # GitHub Actions does not support the semver-specific cooldown keys. Let
+    # every action tag age for three days; major updates still stay in their
+    # separate manual-review group above.
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 3
-      semver-patch-days: 3
+      default-days: 3
 
   # notify relay container base images (golang:1.26-alpine, alpine:3.23).
   # Dependabot will also propose @sha256 digest pins for these.


### PR DESCRIPTION
## Summary

- Replace the unsupported semver-specific GitHub Actions cooldown keys with the supported `default-days: 3` setting.
- Keep major GitHub Actions updates in their separate manual-review group.

## Failure addressed

The Dependabot configuration check on merged helper-readiness commit `f24952ab36c60079b0b4e1548853eedcff11264d` rejected `semver-major-days`, `semver-minor-days`, and `semver-patch-days` for the `github-actions` ecosystem. GitHub's current option reference permits `default-days` for this ecosystem but not the SemVer-specific fields.

## Verification

- Ruby `YAML.safe_load` of `.github/dependabot.yml`
- exact model assertion that the GitHub Actions cooldown is `{ "default-days" => 3 }`
- `git diff --check`

## Scope and compatibility

This changes only Dependabot scheduling metadata. It does not change runtime code, dependencies, security gates, branch protection, application behavior, helper behavior, wire formats, migrations, user data, or release state.