### PR TITLE
fix(notify): resume failed helper publication safely

### DIFF
--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -22,9 +22,15 @@ GATE_FRAGMENTS = [
   "github.event_name == 'workflow_dispatch'",
   "github.ref_type == 'tag'",
   "inputs.release_tag == github.ref_name",
+  "inputs.recovery_run_id == ''",
+  "github.ref == 'refs/heads/main'",
+  "inputs.recovery_run_id != ''",
   "inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE'",
   "github.actor == github.repository_owner",
   "github.triggering_actor == github.repository_owner"
+].freeze
+SOURCE_CHECKOUT_JOBS = %w[
+  publish-image release-binaries rollout-verify finalize-release verify-published
 ].freeze
 EXPECTED_BINARIES = %w[
   vaultsync-notify_linux_amd64
@@ -93,10 +99,12 @@ def flattened_step_text(job)
   end.flatten.compact.join("\n")
 end
 
-def publication_allowed?(event:, ref_type:, ref_name:, release_tag:, confirmation:, actor:, triggering_actor:, owner:)
+def publication_allowed?(event:, ref_type:, ref_name:, release_tag:, recovery_run_id:, confirmation:, actor:,
+                         triggering_actor:, owner:)
+  ref_allowed = (ref_type == "tag" && ref_name == release_tag && recovery_run_id.empty?) ||
+                (ref_type == "branch" && ref_name == "main" && recovery_run_id.match?(/\A[1-9][0-9]*\z/))
   event == "workflow_dispatch" &&
-    ref_type == "tag" &&
-    release_tag == ref_name &&
+    ref_allowed &&
     confirmation == "PUBLISH_NOTIFY_RELEASE" &&
     actor == owner &&
     triggering_actor == owner &&
@@ -145,6 +153,11 @@ dispatch_inputs = workflow_triggers.fetch("workflow_dispatch").fetch("inputs")
   assert_policy(definition["required"] == true && definition["type"] == "string",
                 "workflow_dispatch input #{input} must be a required string")
 end
+recovery_input = dispatch_inputs.fetch("recovery_run_id")
+assert_policy(recovery_input["required"] == false && recovery_input["type"] == "string",
+              "workflow_dispatch recovery_run_id must be an optional string")
+assert_policy(workflow.fetch("concurrency").fetch("group").include?("inputs.release_tag"),
+              "normal and recovery dispatches for one release tag must share a concurrency group")
 
 required_jobs = %w[
   publish-safety-policy notify-guard build-without-push publish-gate publish-image
@@ -197,6 +210,15 @@ jobs.each do |name, job|
     assert_policy(step.fetch("with", {})["persist-credentials"] == false,
                   "#{name} checkout must set persist-credentials: false")
   end
+end
+
+SOURCE_CHECKOUT_JOBS.each do |name|
+  checkout = steps(jobs.fetch(name)).find do |step|
+    step.fetch("uses", "").start_with?("actions/checkout@")
+  end
+  assert_policy(checkout&.fetch("with", {})&.fetch("ref") ==
+                "${{ needs.publish-gate.outputs.release_sha }}",
+                "#{name} must check out the immutable source-tag commit")
 end
 
 security.fetch("jobs").each do |name, job|
@@ -270,6 +292,7 @@ assert_policy(publication_build&.fetch("with", {})&.fetch("platforms") == "linux
               "published image platform set changed")
 
 public_write_guard = "needs.publish-gate.outputs.release_is_public != 'true'"
+recovery_write_guard = "needs.publish-gate.outputs.recovery_mode != 'true'"
 action_write_steps = {
   "publish-image" => [
     "Build and publish the absent release image",
@@ -284,8 +307,9 @@ action_write_steps = {
 action_write_steps.each do |job_name, step_names|
   step_names.each do |step_name|
     step = steps(jobs.fetch(job_name)).find { |candidate| candidate["name"] == step_name }
-    assert_policy(step && step.fetch("if", "").include?(public_write_guard),
-                  "#{job_name}/#{step_name} remains reachable for a public release")
+    condition = step&.fetch("if", "") || ""
+    assert_policy(step && condition.include?(public_write_guard) && condition.include?(recovery_write_guard),
+                  "#{job_name}/#{step_name} remains reachable for a public release or main-ref recovery")
   end
 end
 
@@ -306,9 +330,12 @@ public_integrity_checks.each do |job_name, step_names|
     assert_policy(step &&
                   step.fetch("env", {})["RELEASE_IS_PUBLIC"] ==
                     "${{ needs.publish-gate.outputs.release_is_public }}" &&
+                  step.fetch("env", {})["RECOVERY_MODE"] ==
+                    "${{ needs.publish-gate.outputs.recovery_mode }}" &&
                   step.fetch("run", "").include?('$RELEASE_IS_PUBLIC') &&
+                  step.fetch("run", "").include?('$RECOVERY_MODE') &&
                   step.fetch("run", "").include?("exit 1"),
-                  "#{job_name}/#{step_name} must fail closed on missing public material")
+                  "#{job_name}/#{step_name} must fail closed on missing immutable material")
   end
 end
 
@@ -319,7 +346,12 @@ assert_policy(stage_release &&
               stage_release.fetch("env", {})["RELEASE_IS_PUBLIC"] ==
                 "${{ needs.publish-gate.outputs.release_is_public }}" &&
               stage_release.fetch("run", "").include?('test "$RELEASE_IS_PUBLIC" != true') &&
-              stage_release.fetch("run", "").include?('test "$release_is_draft" = true'),
+              stage_release.fetch("run", "").include?('test "$release_is_draft" = true') &&
+              stage_release.fetch("run", "").include?("gh api graphql") &&
+              stage_release.fetch("run", "").include?("databaseId") &&
+              stage_release.fetch("run", "").include?('releases/${release_id}') &&
+              stage_release.fetch("run", "").include?("|| return 1") &&
+              !stage_release.fetch("run", "").include?("releases/tags"),
               "release creation and asset upload must be unreachable for a public release")
 
 finalize_step = steps(jobs.fetch("finalize-release")).find do |step|
@@ -331,6 +363,10 @@ public_exit = public_branch && finalize_text.index("exit 0", public_branch)
 release_edit = finalize_text.index('gh release edit "$RELEASE_TAG"')
 assert_policy(finalize_text.include?('test "$release_is_draft" = true') &&
               finalize_text.include?('test "$body" = "$(cat /tmp/release-notes.md)"') &&
+              finalize_text.include?("gh api graphql") &&
+              finalize_text.include?("databaseId") &&
+              finalize_text.include?('releases/${release_id}') &&
+              finalize_text.include?("|| return 1") &&
               public_branch && public_exit && release_edit && public_exit < release_edit,
               "rollout evidence and release finalization must be read-only once public")
 
@@ -368,11 +404,17 @@ assert_policy(gate_text.include?("git merge-base --is-ancestor") &&
               "publish gate must bind manifest, tag, verified SHA, and origin/main")
 assert_policy(jobs.fetch("publish-gate").fetch("outputs").fetch("release_is_public") ==
                 "${{ steps.validate.outputs.release_is_public }}" &&
+              jobs.fetch("publish-gate").fetch("outputs").fetch("recovery_mode") ==
+                "${{ steps.validate.outputs.recovery_mode }}" &&
               gate_text.include?("gh api graphql") &&
               gate_text.include?(".data.repository.release") &&
               gate_text.include?('case $release_type in') &&
               gate_text.include?('release_is_public=true') &&
-              gate_text.include?('release_is_public=$release_is_public'),
+              gate_text.include?('release_is_public=$release_is_public') &&
+              gate_text.include?('actions/runs/${RECOVERY_RUN_ID}') &&
+              gate_text.include?('Create or verify the exact draft release and assets') &&
+              gate_text.include?('git checkout --detach "$resolved"') &&
+              gate_text.include?('recovery_mode=$recovery_mode'),
               "publish gate must fail closed and export the finalized public-release state")
 
 assert_policy(spec.fetch("format_version") == 1, "release manifest format changed")
@@ -440,6 +482,7 @@ base = {
   ref_name: spec.fetch("tag"),
   release_tag: spec.fetch("tag"),
   confirmation: "PUBLISH_NOTIFY_RELEASE",
+  recovery_run_id: "",
   actor: owner,
   triggering_actor: owner,
   owner: owner
@@ -447,7 +490,10 @@ base = {
 negative_cases = [
   base.merge(event: "push", ref_type: "branch", ref_name: "main"),
   base.merge(event: "pull_request", ref_type: "branch", ref_name: "pull/1/merge"),
-  base.merge(ref_type: "branch", ref_name: "main", release_tag: "main"),
+  base.merge(ref_type: "branch", ref_name: "main"),
+  base.merge(recovery_run_id: "29324314809"),
+  base.merge(ref_type: "branch", ref_name: "main", recovery_run_id: "0"),
+  base.merge(ref_type: "branch", ref_name: "main", recovery_run_id: "failed-run"),
   base.merge(release_tag: "notify-v2.0.1"),
   base.merge(confirmation: "publish"),
   base.merge(actor: "maintainer"),
@@ -458,6 +504,8 @@ negative_cases.each_with_index do |input, index|
   assert_policy(!publication_allowed?(**input), "negative gate case #{index + 1} unexpectedly publishes")
 end
 assert_policy(publication_allowed?(**base), "exact owner/tag/confirmation gate must remain reachable")
+recovery_base = base.merge(ref_type: "branch", ref_name: "main", recovery_run_id: "29324314809")
+assert_policy(publication_allowed?(**recovery_base), "exact owner/main/failed-run recovery gate must remain reachable")
 assert_policy(resume_action(nil, "sha256:a", mutable: true) == :upload,
               "missing draft assets must be uploadable")
 PUBLICATION_WRITE_KINDS.each do |kind|

--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -13,24 +13,31 @@ DOCKERFILE_PATH = File.join(ROOT, "notify/Dockerfile")
 INSTALL_PATH = File.join(ROOT, "notify/scripts/install.sh")
 COMPOSE_PATH = File.join(ROOT, "notify/docker-compose.yml")
 PINNED_ACTION = /\A[^@]+@[0-9a-f]{40}\z/
-WRITE_JOBS = %w[publish-image release-binaries finalize-release].freeze
-DISPATCH_JOBS = %w[
-  publish-image release-binaries rollout-verify finalize-release verify-published
-].freeze
+WRITE_JOBS = %w[publish-image attest-binaries release-binaries finalize-release].freeze
+NORMAL_ONLY_JOBS = %w[publish-image attest-binaries].freeze
+RECOVERY_ONLY_JOBS = %w[recover-image].freeze
+DUAL_PATH_JOBS = %w[release-binaries rollout-verify finalize-release verify-published].freeze
+AGGREGATE_JOBS = %w[image-ready binary-attestation-ready].freeze
+DISPATCH_JOBS = (NORMAL_ONLY_JOBS + RECOVERY_ONLY_JOBS + DUAL_PATH_JOBS + AGGREGATE_JOBS).freeze
 MANUAL_JOBS = (DISPATCH_JOBS + ["publish-gate"]).freeze
-GATE_FRAGMENTS = [
+COMMON_GATE_FRAGMENTS = [
   "github.event_name == 'workflow_dispatch'",
-  "github.ref_type == 'tag'",
-  "inputs.release_tag == github.ref_name",
-  "inputs.recovery_run_id == ''",
-  "github.ref == 'refs/heads/main'",
-  "inputs.recovery_run_id != ''",
   "inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE'",
   "github.actor == github.repository_owner",
   "github.triggering_actor == github.repository_owner"
 ].freeze
+NORMAL_GATE_FRAGMENTS = [
+  "github.ref_type == 'tag'",
+  "inputs.release_tag == github.ref_name",
+  "inputs.recovery_run_id == ''"
+].freeze
+RECOVERY_GATE_FRAGMENTS = [
+  "github.ref == 'refs/heads/main'",
+  "inputs.recovery_run_id != ''"
+].freeze
 SOURCE_CHECKOUT_JOBS = %w[
-  publish-image release-binaries rollout-verify finalize-release verify-published
+  publish-image recover-image attest-binaries release-binaries rollout-verify
+  finalize-release verify-published
 ].freeze
 EXPECTED_BINARIES = %w[
   vaultsync-notify_linux_amd64
@@ -156,12 +163,19 @@ end
 recovery_input = dispatch_inputs.fetch("recovery_run_id")
 assert_policy(recovery_input["required"] == false && recovery_input["type"] == "string",
               "workflow_dispatch recovery_run_id must be an optional string")
-assert_policy(workflow.fetch("concurrency").fetch("group").include?("inputs.release_tag"),
-              "normal and recovery dispatches for one release tag must share a concurrency group")
+concurrency_group = workflow.fetch("concurrency").fetch("group")
+%w[inputs.release_tag github.actor github.triggering_actor inputs.confirmation github.run_id].each do |fragment|
+  assert_policy(concurrency_group.include?(fragment),
+                "publication concurrency group is missing #{fragment}")
+end
+assert_policy(workflow.fetch("concurrency").fetch("cancel-in-progress") ==
+                "${{ github.event_name != 'workflow_dispatch' }}",
+              "manual publications must queue without canceling an active run")
 
 required_jobs = %w[
   publish-safety-policy notify-guard build-without-push publish-gate publish-image
-  release-binaries rollout-verify finalize-release verify-published
+  recover-image image-ready attest-binaries binary-attestation-ready release-binaries
+  rollout-verify finalize-release verify-published
 ]
 assert_policy((required_jobs - jobs.keys).empty?, "required publication-safety jobs are missing")
 assert_policy(jobs.fetch("build-without-push").fetch("if") == "github.event_name != 'workflow_dispatch'",
@@ -181,20 +195,30 @@ write_jobs = jobs.select do |_name, job|
   job.fetch("permissions", {}).value?("write")
 end.keys.sort
 assert_policy(write_jobs == WRITE_JOBS.sort,
-              "only the image, binary staging, and finalization jobs may receive write permissions")
+              "only normal publication, draft staging, and finalization jobs may receive write permissions")
 assert_policy(jobs.fetch("publish-image").fetch("permissions") == {
                 "contents" => "read",
                 "packages" => "write",
                 "id-token" => "write",
                 "attestations" => "write"
               }, "publish-image permissions changed")
-assert_policy(jobs.fetch("release-binaries").fetch("permissions") == {
-                "contents" => "write",
+assert_policy(jobs.fetch("recover-image").fetch("permissions") == {
+                "contents" => "read",
+                "packages" => "read"
+              }, "recover-image must remain registry-read-only")
+assert_policy(jobs.fetch("attest-binaries").fetch("permissions") == {
+                "contents" => "read",
                 "id-token" => "write",
                 "attestations" => "write"
-              }, "release-binaries permissions changed")
+              }, "attest-binaries permissions changed")
+assert_policy(jobs.fetch("release-binaries").fetch("permissions") == { "contents" => "write" },
+              "release-binaries must receive only draft-asset write permission")
 assert_policy(jobs.fetch("finalize-release").fetch("permissions") == { "contents" => "write" },
               "finalize-release permissions changed")
+%w[image-ready binary-attestation-ready].each do |name|
+  assert_policy(jobs.fetch(name).fetch("permissions") == { "contents" => "read" },
+                "#{name} must remain read-only")
+end
 
 jobs.each do |name, job|
   steps(job).each do |step|
@@ -216,7 +240,7 @@ SOURCE_CHECKOUT_JOBS.each do |name|
   checkout = steps(jobs.fetch(name)).find do |step|
     step.fetch("uses", "").start_with?("actions/checkout@")
   end
-  assert_policy(checkout&.fetch("with", {})&.fetch("ref") ==
+  assert_policy(checkout&.dig("with", "ref") ==
                 "${{ needs.publish-gate.outputs.release_sha }}",
                 "#{name} must check out the immutable source-tag commit")
 end
@@ -235,8 +259,10 @@ security.fetch("jobs").each do |name, job|
 end
 
 login_jobs = jobs.select { |_name, job| flattened_step_text(job).include?("docker/login-action@") }.keys
-assert_policy(login_jobs == %w[publish-image verify-published],
-              "registry login must exist only in image publication and read-only public verification")
+assert_policy(login_jobs == %w[publish-image recover-image verify-published],
+              "registry login must exist only in image publication and read-only verification")
+assert_policy(jobs.fetch("recover-image").fetch("permissions").fetch("packages") == "read",
+              "recovery image verifier registry permission must remain read-only")
 assert_policy(jobs.fetch("verify-published").fetch("permissions").fetch("packages") == "read",
               "public verifier registry permission must remain read-only")
 release_mutation_jobs = jobs.select do |_name, job|
@@ -292,14 +318,13 @@ assert_policy(publication_build&.fetch("with", {})&.fetch("platforms") == "linux
               "published image platform set changed")
 
 public_write_guard = "needs.publish-gate.outputs.release_is_public != 'true'"
-recovery_write_guard = "needs.publish-gate.outputs.recovery_mode != 'true'"
 action_write_steps = {
   "publish-image" => [
     "Build and publish the absent release image",
     "Attest image provenance",
     "Attest image SBOM"
   ],
-  "release-binaries" => [
+  "attest-binaries" => [
     "Attest binary provenance",
     "Attest binary SBOM"
   ]
@@ -308,8 +333,8 @@ action_write_steps.each do |job_name, step_names|
   step_names.each do |step_name|
     step = steps(jobs.fetch(job_name)).find { |candidate| candidate["name"] == step_name }
     condition = step&.fetch("if", "") || ""
-    assert_policy(step && condition.include?(public_write_guard) && condition.include?(recovery_write_guard),
-                  "#{job_name}/#{step_name} remains reachable for a public release or main-ref recovery")
+    assert_policy(step && condition.include?(public_write_guard),
+                  "#{job_name}/#{step_name} remains reachable for a public release")
   end
 end
 
@@ -319,7 +344,7 @@ public_integrity_checks = {
     "Check for existing repository provenance",
     "Check for existing repository SBOM attestation"
   ],
-  "release-binaries" => [
+  "attest-binaries" => [
     "Check for existing exact binary provenance",
     "Check for existing exact binary SBOM attestation"
   ]
@@ -330,14 +355,28 @@ public_integrity_checks.each do |job_name, step_names|
     assert_policy(step &&
                   step.fetch("env", {})["RELEASE_IS_PUBLIC"] ==
                     "${{ needs.publish-gate.outputs.release_is_public }}" &&
-                  step.fetch("env", {})["RECOVERY_MODE"] ==
-                    "${{ needs.publish-gate.outputs.recovery_mode }}" &&
                   step.fetch("run", "").include?('$RELEASE_IS_PUBLIC') &&
-                  step.fetch("run", "").include?('$RECOVERY_MODE') &&
                   step.fetch("run", "").include?("exit 1"),
                   "#{job_name}/#{step_name} must fail closed on missing immutable material")
   end
 end
+
+{
+  "Verify exact binary provenance" => "--source-digest",
+  "Verify exact binary SBOM attestation" => "--predicate-type"
+}.each do |step_name, required_fragment|
+  step = steps(jobs.fetch("release-binaries")).find { |candidate| candidate["name"] == step_name }
+  assert_policy(step && step.fetch("run", "").include?(required_fragment) &&
+                step.fetch("run", "").include?("exit 1") &&
+                !step.fetch("run", "").include?("actions/attest"),
+                "release-binaries/#{step_name} must verify existing tag-bound attestations read-only")
+end
+
+recovery_text = flattened_step_text(jobs.fetch("recover-image"))
+assert_policy(recovery_text.include?("gh attestation verify") &&
+              !recovery_text.include?("actions/attest@") &&
+              !recovery_text.include?("docker/build-push-action@"),
+              "image recovery must only verify the already-published image and attestations")
 
 stage_release = steps(jobs.fetch("release-binaries")).find do |step|
   step["name"] == "Create or verify the exact draft release and assets"
@@ -345,7 +384,10 @@ end
 assert_policy(stage_release &&
               stage_release.fetch("env", {})["RELEASE_IS_PUBLIC"] ==
                 "${{ needs.publish-gate.outputs.release_is_public }}" &&
+              stage_release.fetch("env", {})["RECOVERY_MODE"] ==
+                "${{ needs.publish-gate.outputs.recovery_mode }}" &&
               stage_release.fetch("run", "").include?('test "$RELEASE_IS_PUBLIC" != true') &&
+              stage_release.fetch("run", "").include?('test "$RECOVERY_MODE" != true') &&
               stage_release.fetch("run", "").include?('test "$release_is_draft" = true') &&
               stage_release.fetch("run", "").include?("gh api graphql") &&
               stage_release.fetch("run", "").include?("databaseId") &&
@@ -373,26 +415,84 @@ assert_policy(finalize_text.include?('test "$release_is_draft" = true') &&
 DISPATCH_JOBS.each do |name|
   job = jobs.fetch(name)
   condition = job.fetch("if")
-  GATE_FRAGMENTS.each do |fragment|
+  COMMON_GATE_FRAGMENTS.each do |fragment|
     assert_policy(condition.include?(fragment), "#{name} is missing gate condition #{fragment}")
   end
   assert_policy((%w[publish-safety-policy notify-guard publish-gate] - job.fetch("needs")).empty?,
                 "#{name} must depend on policy, tests, and the owner gate")
 end
-assert_policy(jobs.fetch("release-binaries").fetch("needs").include?("publish-image"),
-              "binary staging must follow image publication")
-binary_scan_steps = steps(jobs.fetch("release-binaries")).select do |step|
-  step.fetch("uses", "").start_with?("aquasecurity/trivy-action@") &&
-    step.fetch("with", {}).fetch("scan-ref", "") == "notify/dist"
+
+NORMAL_ONLY_JOBS.each do |name|
+  condition = jobs.fetch(name).fetch("if")
+  NORMAL_GATE_FRAGMENTS.each do |fragment|
+    assert_policy(condition.include?(fragment), "#{name} is missing normal tag gate #{fragment}")
+  end
+  RECOVERY_GATE_FRAGMENTS.each do |fragment|
+    assert_policy(!condition.include?(fragment), "#{name} must be unreachable from main-ref recovery")
+  end
 end
-assert_policy(binary_scan_steps.length == 2 &&
-              binary_scan_steps.all? { |step| step.fetch("with").fetch("scan-type") == "rootfs" },
-              "binary vulnerability and SBOM scans must inspect compiled Go binaries as root filesystems")
-assert_policy(jobs.fetch("rollout-verify").fetch("needs").include?("release-binaries"),
-              "published rollout must follow complete draft staging")
-assert_policy(jobs.fetch("finalize-release").fetch("needs").include?("rollout-verify"),
+
+RECOVERY_ONLY_JOBS.each do |name|
+  condition = jobs.fetch(name).fetch("if")
+  RECOVERY_GATE_FRAGMENTS.each do |fragment|
+    assert_policy(condition.include?(fragment), "#{name} is missing recovery gate #{fragment}")
+  end
+  NORMAL_GATE_FRAGMENTS.each do |fragment|
+    assert_policy(!condition.include?(fragment), "#{name} must be unreachable from normal tag publication")
+  end
+end
+
+DUAL_PATH_JOBS.each do |name|
+  condition = jobs.fetch(name).fetch("if")
+  (NORMAL_GATE_FRAGMENTS + RECOVERY_GATE_FRAGMENTS).each do |fragment|
+    assert_policy(condition.include?(fragment), "#{name} is missing dual-path gate #{fragment}")
+  end
+end
+
+AGGREGATE_JOBS.each do |name|
+  condition = jobs.fetch(name).fetch("if")
+  assert_policy(condition.include?("always()") &&
+                condition.include?("needs.publish-gate.outputs.recovery_mode"),
+                "#{name} must explicitly select one successful publication path")
+end
+
+recovery_reachable_jobs = %w[
+  recover-image image-ready binary-attestation-ready release-binaries
+  rollout-verify finalize-release verify-published
+]
+recovery_reachable_jobs.each do |name|
+  permissions = jobs.fetch(name).fetch("permissions", {})
+  assert_policy(!permissions.key?("id-token") && !permissions.key?("attestations") &&
+                !flattened_step_text(jobs.fetch(name)).include?("actions/attest@"),
+                "#{name} must not receive OIDC or attestation mutation capability during recovery")
+end
+
+assert_policy((%w[publish-image recover-image] - jobs.fetch("image-ready").fetch("needs")).empty?,
+              "image selector must require both mutually exclusive image paths")
+assert_policy(jobs.fetch("attest-binaries").fetch("needs").include?("image-ready"),
+              "normal binary attestation must follow immutable image selection")
+assert_policy((%w[image-ready attest-binaries] -
+               jobs.fetch("binary-attestation-ready").fetch("needs")).empty?,
+              "binary attestation selector must require image selection and the tag-only attestation job")
+assert_policy((%w[image-ready binary-attestation-ready] -
+               jobs.fetch("release-binaries").fetch("needs")).empty?,
+              "binary staging must follow immutable image and attestation selection")
+
+%w[attest-binaries release-binaries].each do |name|
+  binary_scan_steps = steps(jobs.fetch(name)).select do |step|
+    step.fetch("uses", "").start_with?("aquasecurity/trivy-action@") &&
+      step.fetch("with", {}).fetch("scan-ref", "") == "notify/dist"
+  end
+  assert_policy(binary_scan_steps.length == 2 &&
+                binary_scan_steps.all? { |step| step.fetch("with").fetch("scan-type") == "rootfs" },
+                "#{name} vulnerability and SBOM scans must inspect compiled Go binaries as root filesystems")
+end
+
+assert_policy((%w[release-binaries image-ready] - jobs.fetch("rollout-verify").fetch("needs")).empty?,
+              "published rollout must follow complete draft staging and immutable image selection")
+assert_policy((%w[rollout-verify image-ready] - jobs.fetch("finalize-release").fetch("needs")).empty?,
               "release finalization must follow the published rollback proof")
-assert_policy(jobs.fetch("verify-published").fetch("needs").include?("finalize-release"),
+assert_policy((%w[finalize-release image-ready] - jobs.fetch("verify-published").fetch("needs")).empty?,
               "read-only public verification must follow finalization")
 
 gate_text = flattened_step_text(jobs.fetch("publish-gate"))

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,16 +20,20 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "Existing notify-vX.Y.Z tag selected as the workflow ref"
+        description: "Existing notify-vX.Y.Z source tag"
         required: true
         type: string
       confirmation:
         description: "Type PUBLISH_NOTIFY_RELEASE to publish images and binaries"
         required: true
         type: string
+      recovery_run_id:
+        description: "Failed tag-bound publication run to resume from main; empty for a normal tag dispatch"
+        required: false
+        type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
   # A second owner dispatch queues behind an active publication. It may verify
   # and resume identical draft material but must never replace an artifact.
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
@@ -136,6 +140,7 @@ jobs:
       rollback_image: ${{ steps.validate.outputs.rollback_image }}
       rollback_commit: ${{ steps.validate.outputs.rollback_commit }}
       release_is_public: ${{ steps.validate.outputs.release_is_public }}
+      recovery_mode: ${{ steps.validate.outputs.recovery_mode }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -152,14 +157,14 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           RELEASE_TAG_INPUT: ${{ inputs.release_tag }}
           CONFIRMATION: ${{ inputs.confirmation }}
+          RECOVERY_RUN_ID: ${{ inputs.recovery_run_id }}
           ACTOR: ${{ github.actor }}
           TRIGGERING_ACTOR: ${{ github.triggering_actor }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          RELEASE_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           test "$EVENT_NAME" = workflow_dispatch
-          test "$REF_TYPE" = tag
           test "$ACTOR" = "$REPOSITORY_OWNER"
           test "$TRIGGERING_ACTOR" = "$REPOSITORY_OWNER"
           test "$CONFIRMATION" = PUBLISH_NOTIFY_RELEASE
@@ -175,15 +180,47 @@ jobs:
           test "$image" = "$IMAGE_NAME"
           test "$version_image" = "${IMAGE_NAME}:${version}"
           test "$RELEASE_TAG_INPUT" = "$release_tag"
-          test "$REF_NAME" = "$release_tag"
 
           git fetch origin main --tags
           test "$(git cat-file -t "refs/tags/${release_tag}")" = commit
           resolved=$(git rev-parse --verify "refs/tags/${release_tag}^{commit}")
-          test "$resolved" = "$RELEASE_SHA"
           git show-ref --verify --quiet refs/remotes/origin/main
-          git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main
-          test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}" --jq .commit.verification.verified)" = true
+          git merge-base --is-ancestor "$resolved" refs/remotes/origin/main
+          test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/${resolved}" --jq .commit.verification.verified)" = true
+
+          recovery_mode=false
+          case "$REF_TYPE" in
+            tag)
+              test "$REF_NAME" = "$release_tag"
+              test -z "$RECOVERY_RUN_ID"
+              test "$WORKFLOW_SHA" = "$resolved"
+              ;;
+            branch)
+              test "$REF_NAME" = main
+              printf '%s\n' "$RECOVERY_RUN_ID" | grep -Eq '^[1-9][0-9]*$'
+              test "$WORKFLOW_SHA" = "$(git rev-parse refs/remotes/origin/main)"
+              test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/${WORKFLOW_SHA}" --jq .commit.verification.verified)" = true
+
+              recovery_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RECOVERY_RUN_ID}")
+              test "$(jq -r .id <<<"$recovery_json")" = "$RECOVERY_RUN_ID"
+              test "$(jq -r .event <<<"$recovery_json")" = workflow_dispatch
+              test "$(jq -r .path <<<"$recovery_json")" = .github/workflows/docker.yml
+              test "$(jq -r .head_branch <<<"$recovery_json")" = "$release_tag"
+              test "$(jq -r .head_sha <<<"$recovery_json")" = "$resolved"
+              test "$(jq -r .conclusion <<<"$recovery_json")" = failure
+              test "$(jq -r .actor.login <<<"$recovery_json")" = "$REPOSITORY_OWNER"
+              test "$(jq -r .triggering_actor.login <<<"$recovery_json")" = "$REPOSITORY_OWNER"
+
+              recovery_jobs=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RECOVERY_RUN_ID}/jobs?per_page=100")
+              test "$(jq '[.jobs[] | select(.name == "Stage Release Binaries" and .conclusion == "failure")] | length' <<<"$recovery_jobs")" = 1
+              test "$(jq '[.jobs[] | select(.name == "Stage Release Binaries") | .steps[] | select(.name == "Create or verify the exact draft release and assets" and .conclusion == "failure")] | length' <<<"$recovery_jobs")" = 1
+              test "$(jq '[.jobs[] | select(.name == "Publish Image" and .conclusion == "success")] | length' <<<"$recovery_jobs")" = 1
+              test "$(jq '[.jobs[] | select(.name == "Published Helper Rollout" and .conclusion == "skipped")] | length' <<<"$recovery_jobs")" = 1
+              test "$(jq '[.jobs[] | select(.name == "Finalize Helper Release" and .conclusion == "skipped")] | length' <<<"$recovery_jobs")" = 1
+              recovery_mode=true
+              ;;
+            *) exit 1 ;;
+          esac
 
           test "$(git rev-parse --verify "refs/tags/${rollback_tag}^{commit}")" = "$rollback_commit"
           gh release view "$rollback_tag" --repo "$GITHUB_REPOSITORY" >/dev/null
@@ -220,14 +257,24 @@ jobs:
             *) exit 1 ;;
           esac
 
+          if [ "$recovery_mode" = true ]; then
+            test "$release_type" = object
+            test "$(jq -r .isDraft <<<"$release_json")" = true
+          fi
+
+          manifest_digest=$(sha256sum "$RELEASE_SPEC" | awk '{print $1}')
+          git checkout --detach "$resolved"
+          test "$(sha256sum "$RELEASE_SPEC" | awk '{print $1}')" = "$manifest_digest"
+
           {
             echo "version=$version"
             echo "release_tag=$release_tag"
-            echo "release_sha=$RELEASE_SHA"
+            echo "release_sha=$resolved"
             echo "image=$image"
             echo "rollback_image=$rollback_image"
             echo "rollback_commit=$rollback_commit"
             echo "release_is_public=$release_is_public"
+            echo "recovery_mode=$recovery_mode"
           } >> "$GITHUB_OUTPUT"
 
       - name: Scan the exact helper source before any publication mutation
@@ -244,8 +291,8 @@ jobs:
     name: Publish Image
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'tag' &&
-      inputs.release_tag == github.ref_name &&
+      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
+       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -265,6 +312,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
           persist-credentials: false
 
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
@@ -284,6 +332,7 @@ jobs:
           VERSION: ${{ needs.publish-gate.outputs.version }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           token=$(curl -fsSL "https://ghcr.io/token?scope=repository:psimaker/vaultsync-notify:pull" | jq -er .token)
@@ -305,6 +354,10 @@ jobs:
               echo "public release image is missing; refusing to publish on a finalized release" >&2
               exit 1
             fi
+            if [ "$RECOVERY_MODE" = true ]; then
+              echo "recovery requires the exact image from the failed tag-bound run; refusing to publish it from main" >&2
+              exit 1
+            fi
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "GHCR lookup failed with HTTP ${http_status}; refusing to treat the version tag as absent" >&2
@@ -322,6 +375,7 @@ jobs:
       - name: Build and publish the absent release image
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
+          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.existing-image.outputs.present != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: build
@@ -382,6 +436,7 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           if gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo "$GITHUB_REPOSITORY" \
@@ -389,8 +444,8 @@ jobs:
             --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
-            if [ "$RELEASE_IS_PUBLIC" = true ]; then
-              echo "public image provenance is missing or mismatched; refusing to create it" >&2
+            if [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; then
+              echo "immutable image provenance is missing or mismatched; refusing to create it" >&2
               exit 1
             fi
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -399,6 +454,7 @@ jobs:
       - name: Attest image provenance
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
+          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.image-provenance.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -415,6 +471,7 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           if gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo "$GITHUB_REPOSITORY" \
@@ -423,8 +480,8 @@ jobs:
             --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
-            if [ "$RELEASE_IS_PUBLIC" = true ]; then
-              echo "public image SBOM attestation is missing or mismatched; refusing to create it" >&2
+            if [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; then
+              echo "immutable image SBOM attestation is missing or mismatched; refusing to create it" >&2
               exit 1
             fi
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -433,6 +490,7 @@ jobs:
       - name: Attest image SBOM
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
+          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.image-sbom.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -445,8 +503,8 @@ jobs:
     name: Stage Release Binaries
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'tag' &&
-      inputs.release_tag == github.ref_name &&
+      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
+       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -464,6 +522,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -519,9 +578,10 @@ jobs:
       - name: Normalize deterministic SBOM metadata
         env:
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
         run: |
           set -euo pipefail
-          jq --arg namespace "https://github.com/${GITHUB_REPOSITORY}/sbom/${RELEASE_TAG}/${GITHUB_SHA}" \
+          jq --arg namespace "https://github.com/${GITHUB_REPOSITORY}/sbom/${RELEASE_TAG}/${RELEASE_SHA}" \
             '.creationInfo.created = "1970-01-01T00:00:00Z" | .documentNamespace = $namespace' \
             notify/dist/SBOM.spdx.json > /tmp/SBOM.spdx.json
           mv /tmp/SBOM.spdx.json notify/dist/SBOM.spdx.json
@@ -533,6 +593,7 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           present=true
@@ -543,8 +604,8 @@ jobs:
               present=false
             fi
           done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
-          if [ "$RELEASE_IS_PUBLIC" = true ] && [ "$present" != true ]; then
-            echo "public binary provenance is missing or mismatched; refusing to create it" >&2
+          if { [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; } && [ "$present" != true ]; then
+            echo "immutable binary provenance is missing or mismatched; refusing to create it" >&2
             exit 1
           fi
           echo "present=$present" >> "$GITHUB_OUTPUT"
@@ -552,6 +613,7 @@ jobs:
       - name: Attest binary provenance
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
+          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.binary-provenance.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -564,6 +626,7 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           present=true
@@ -575,8 +638,8 @@ jobs:
               present=false
             fi
           done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
-          if [ "$RELEASE_IS_PUBLIC" = true ] && [ "$present" != true ]; then
-            echo "public binary SBOM attestation is missing or mismatched; refusing to create it" >&2
+          if { [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; } && [ "$present" != true ]; then
+            echo "immutable binary SBOM attestation is missing or mismatched; refusing to create it" >&2
             exit 1
           fi
           echo "present=$present" >> "$GITHUB_OUTPUT"
@@ -584,6 +647,7 @@ jobs:
       - name: Attest binary SBOM
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
+          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.binary-sbom.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -659,16 +723,44 @@ jobs:
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
         run: |
           set -euo pipefail
-          if release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>/dev/null); then
-            test "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG"
-            test "$(jq -r .prerelease <<<"$release_json")" = false
-            test "$(jq -r .name <<<"$release_json")" = "vaultsync-notify ${RELEASE_VERSION}"
-          else
-            test "$RELEASE_IS_PUBLIC" != true
-            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --verify-tag \
-              --draft --latest=false --title "vaultsync-notify ${RELEASE_VERSION}" \
-              --notes "Staged helper release. Publication remains blocked until the digest-bound supported-host rollback and post-publication gates succeed."
-          fi
+          resolve_release() {
+            repository_owner=${GITHUB_REPOSITORY%%/*}
+            repository_name=${GITHUB_REPOSITORY#*/}
+            # GraphQL includes drafts, unlike the REST release-by-tag endpoint.
+            # Keep the query literal so shell expansion cannot alter its variables.
+            # shellcheck disable=SC2016
+            lookup=$(gh api graphql \
+              -F owner="$repository_owner" -F name="$repository_name" -F tag="$RELEASE_TAG" \
+              -f query='query($owner: String!, $name: String!, $tag: String!) {
+                repository(owner: $owner, name: $name) {
+                  release(tagName: $tag) { databaseId }
+                }
+              }') || return 1
+            jq -e '.data.repository != null and ((.errors // []) | length == 0)' <<<"$lookup" >/dev/null || return 1
+            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || return 1
+            if [ -z "$release_id" ]; then
+              printf 'null\n'
+              return
+            fi
+            printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || return 1
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || return 1
+          }
+
+          release_json=$(resolve_release)
+          case $(jq -r type <<<"$release_json") in
+            object)
+              test "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG"
+              test "$(jq -r .prerelease <<<"$release_json")" = false
+              test "$(jq -r .name <<<"$release_json")" = "vaultsync-notify ${RELEASE_VERSION}"
+              ;;
+            null)
+              test "$RELEASE_IS_PUBLIC" != true
+              gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --verify-tag \
+                --draft --latest=false --title "vaultsync-notify ${RELEASE_VERSION}" \
+                --notes "Staged helper release. Publication remains blocked until the digest-bound supported-host rollback and post-publication gates succeed."
+              ;;
+            *) exit 1 ;;
+          esac
 
           mapfile -t binaries < <(jq -r '.binaries[]' "$RELEASE_SPEC")
           files=()
@@ -676,7 +768,8 @@ jobs:
             files+=("notify/dist/$name")
           done
 
-          release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          release_json=$(resolve_release)
+          test "$(jq -r type <<<"$release_json")" = object
           release_is_draft=$(jq -r .draft <<<"$release_json")
           case $release_is_draft in true|false) ;; *) exit 1 ;; esac
           while IFS= read -r existing_name; do
@@ -692,7 +785,7 @@ jobs:
             else
               test "$release_is_draft" = true
               gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY"
-              release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+              release_json=$(resolve_release)
               test "$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .digest' <<<"$release_json")" = "$expected"
             fi
           done
@@ -701,8 +794,8 @@ jobs:
     name: Published Helper Rollout
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'tag' &&
-      inputs.release_tag == github.ref_name &&
+      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
+       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -720,6 +813,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -767,8 +861,8 @@ jobs:
     name: Finalize Helper Release
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'tag' &&
-      inputs.release_tag == github.ref_name &&
+      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
+       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -786,6 +880,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -805,7 +900,26 @@ jobs:
           git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main
           test "$(gh api "repos/${GITHUB_REPOSITORY}/commits/${RELEASE_SHA}" --jq .commit.verification.verified)" = true
 
-          release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          resolve_release() {
+            repository_owner=${GITHUB_REPOSITORY%%/*}
+            repository_name=${GITHUB_REPOSITORY#*/}
+            # GraphQL includes drafts, unlike the REST release-by-tag endpoint.
+            # Keep the query literal so shell expansion cannot alter its variables.
+            # shellcheck disable=SC2016
+            lookup=$(gh api graphql \
+              -F owner="$repository_owner" -F name="$repository_name" -F tag="$RELEASE_TAG" \
+              -f query='query($owner: String!, $name: String!, $tag: String!) {
+                repository(owner: $owner, name: $name) {
+                  release(tagName: $tag) { databaseId }
+                }
+              }') || return 1
+            jq -e '.data.repository != null and ((.errors // []) | length == 0)' <<<"$lookup" >/dev/null || return 1
+            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || return 1
+            printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || return 1
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || return 1
+          }
+
+          release_json=$(resolve_release)
           release_is_draft=$(jq -r .draft <<<"$release_json")
           case $release_is_draft in true|false) ;; *) exit 1 ;; esac
           evidence_name=ROLLOUT-EVIDENCE.txt
@@ -855,7 +969,7 @@ jobs:
             gh release upload "$RELEASE_TAG" /tmp/$evidence_name --repo "$GITHUB_REPOSITORY"
           fi
 
-          release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          release_json=$(resolve_release)
           mapfile -t expected_names < <(jq -r '.release_assets[]' "$RELEASE_SPEC" | sort)
           mapfile -t actual_names < <(jq -r '.assets[].name' <<<"$release_json" | sort)
           test "${expected_names[*]}" = "${actual_names[*]}"
@@ -897,7 +1011,7 @@ jobs:
             --title "vaultsync-notify ${RELEASE_VERSION}" --notes-file /tmp/release-notes.md \
             --draft=false --latest=false
 
-          release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          release_json=$(resolve_release)
           test "$(jq -r .draft <<<"$release_json")" = false
           test "$(jq -r .name <<<"$release_json")" = "vaultsync-notify ${RELEASE_VERSION}"
           body=$(jq -er .body <<<"$release_json")
@@ -907,8 +1021,8 @@ jobs:
     name: Verify Published Helper
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref_type == 'tag' &&
-      inputs.release_tag == github.ref_name &&
+      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
+       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -928,6 +1042,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && github.actor == github.repository_owner && github.triggering_actor == github.repository_owner && inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' && inputs.release_tag || github.event_name == 'workflow_dispatch' && github.run_id || github.ref }}
   # A second owner dispatch queues behind an active publication. It may verify
   # and resume identical draft material but must never replace an artifact.
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
@@ -291,8 +291,9 @@ jobs:
     name: Publish Image
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
-       (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
+      github.ref_type == 'tag' &&
+      inputs.release_tag == github.ref_name &&
+      inputs.recovery_run_id == '' &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
       github.triggering_actor == github.repository_owner
@@ -332,7 +333,6 @@ jobs:
           VERSION: ${{ needs.publish-gate.outputs.version }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
-          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           token=$(curl -fsSL "https://ghcr.io/token?scope=repository:psimaker/vaultsync-notify:pull" | jq -er .token)
@@ -354,10 +354,6 @@ jobs:
               echo "public release image is missing; refusing to publish on a finalized release" >&2
               exit 1
             fi
-            if [ "$RECOVERY_MODE" = true ]; then
-              echo "recovery requires the exact image from the failed tag-bound run; refusing to publish it from main" >&2
-              exit 1
-            fi
             echo "present=false" >> "$GITHUB_OUTPUT"
           else
             echo "GHCR lookup failed with HTTP ${http_status}; refusing to treat the version tag as absent" >&2
@@ -375,7 +371,6 @@ jobs:
       - name: Build and publish the absent release image
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
-          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.existing-image.outputs.present != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         id: build
@@ -436,7 +431,6 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
-          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           if gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo "$GITHUB_REPOSITORY" \
@@ -444,8 +438,8 @@ jobs:
             --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
-            if [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; then
-              echo "immutable image provenance is missing or mismatched; refusing to create it" >&2
+            if [ "$RELEASE_IS_PUBLIC" = true ]; then
+              echo "public image provenance is missing or mismatched; refusing to create it" >&2
               exit 1
             fi
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -454,7 +448,6 @@ jobs:
       - name: Attest image provenance
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
-          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.image-provenance.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -471,7 +464,6 @@ jobs:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
-          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           if gh attestation verify "oci://${IMAGE}@${DIGEST}" --repo "$GITHUB_REPOSITORY" \
@@ -480,8 +472,8 @@ jobs:
             --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
-            if [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; then
-              echo "immutable image SBOM attestation is missing or mismatched; refusing to create it" >&2
+            if [ "$RELEASE_IS_PUBLIC" = true ]; then
+              echo "public image SBOM attestation is missing or mismatched; refusing to create it" >&2
               exit 1
             fi
             echo "present=false" >> "$GITHUB_OUTPUT"
@@ -490,7 +482,6 @@ jobs:
       - name: Attest image SBOM
         if: >-
           needs.publish-gate.outputs.release_is_public != 'true' &&
-          needs.publish-gate.outputs.recovery_mode != 'true' &&
           steps.image-sbom.outputs.present != 'true'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
@@ -498,6 +489,310 @@ jobs:
           subject-digest: ${{ steps.select-image.outputs.digest }}
           sbom-path: /tmp/vaultsync-notify-image.spdx.json
           push-to-registry: true
+
+  recover-image:
+    name: Recover Published Image (read-only)
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      inputs.recovery_run_id != '' &&
+      inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner
+    needs:
+      - publish-safety-policy
+      - notify-guard
+      - publish-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      digest: ${{ steps.verify-image.outputs.digest }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify the immutable recovery image and attestations
+        id: verify-image
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ needs.publish-gate.outputs.image }}
+          VERSION: ${{ needs.publish-gate.outputs.version }}
+          RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          manifest=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{json .Manifest}}')
+          digest=$(jq -er '.digest | select(test("^sha256:[0-9a-f]{64}$"))' <<<"$manifest")
+          test "$(jq '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64")] | length' <<<"$manifest")" = 1
+          test "$(jq '[.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64")] | length' <<<"$manifest")" = 1
+          docker pull "${IMAGE}@${digest}" >/dev/null
+          test "$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' "${IMAGE}@${digest}")" = "$RELEASE_SHA"
+          test "$(docker image inspect --format '{{index .Config.Labels "org.opencontainers.image.version"}}' "${IMAGE}@${digest}")" = "$VERSION"
+          test "$(docker run --rm --network none --read-only --cap-drop ALL --security-opt no-new-privileges "${IMAGE}@${digest}" --version)" = "vaultsync-notify $VERSION"
+          gh attestation verify "oci://${IMAGE}@${digest}" --repo "$GITHUB_REPOSITORY" \
+            --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null
+          gh attestation verify "oci://${IMAGE}@${digest}" --repo "$GITHUB_REPOSITORY" \
+            --predicate-type https://spdx.dev/Document/v2.3 \
+            --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Scan the immutable recovery image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ needs.publish-gate.outputs.image }}@${{ steps.verify-image.outputs.digest }}
+          scanners: vuln,secret
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+  image-ready:
+    name: Select Immutable Helper Image
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      needs.publish-safety-policy.result == 'success' &&
+      needs.notify-guard.result == 'success' &&
+      needs.publish-gate.result == 'success' &&
+      ((needs.publish-gate.outputs.recovery_mode == 'true' &&
+        needs.recover-image.result == 'success' && needs.publish-image.result == 'skipped') ||
+       (needs.publish-gate.outputs.recovery_mode != 'true' &&
+        needs.publish-image.result == 'success' && needs.recover-image.result == 'skipped'))
+    needs:
+      - publish-safety-policy
+      - notify-guard
+      - publish-gate
+      - publish-image
+      - recover-image
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      digest: ${{ steps.select.outputs.digest }}
+    steps:
+      - name: Select the only eligible immutable digest
+        id: select
+        env:
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
+          PUBLISHED_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          RECOVERED_DIGEST: ${{ needs.recover-image.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ "$RECOVERY_MODE" = true ]; then
+            test -z "$PUBLISHED_DIGEST"
+            digest=$RECOVERED_DIGEST
+          else
+            test -z "$RECOVERED_DIGEST"
+            digest=$PUBLISHED_DIGEST
+          fi
+          printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  attest-binaries:
+    name: Attest Release Binaries
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_type == 'tag' &&
+      inputs.release_tag == github.ref_name &&
+      inputs.recovery_run_id == '' &&
+      inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner
+    needs:
+      - publish-safety-policy
+      - notify-guard
+      - publish-gate
+      - image-ready
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.publish-gate.outputs.release_sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: notify/go.mod
+          cache: false
+
+      - name: Cross-compile every binary twice for attestation
+        working-directory: notify
+        env:
+          RELEASE_VERSION: ${{ needs.publish-gate.outputs.version }}
+        run: |
+          set -euo pipefail
+          rm -rf dist verify-dist
+          mkdir -p dist verify-dist
+          mapfile -t binaries < <(jq -r '.binaries[]' release.json)
+          for output_directory in dist verify-dist; do
+            for target in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+              goos=${target%/*}
+              goarch=${target#*/}
+              out="${output_directory}/vaultsync-notify_${goos}_${goarch}"
+              [ "$goos" = windows ] && out="$out.exe"
+              GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -trimpath -buildvcs=false \
+                -ldflags="-s -w -X main.version=${RELEASE_VERSION}" -o "$out" .
+            done
+          done
+          for name in "${binaries[@]}"; do
+            cmp "dist/$name" "verify-dist/$name"
+          done
+          (cd dist && sha256sum -- "${binaries[@]}" > SHA256SUMS)
+
+      - name: Scan attested binaries for vulnerabilities and secrets
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: rootfs
+          scan-ref: notify/dist
+          scanners: vuln,secret
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Create deterministic attestation SPDX SBOM
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: rootfs
+          scan-ref: notify/dist
+          format: spdx-json
+          output: notify/dist/SBOM.spdx.json
+
+      - name: Normalize deterministic attestation SBOM metadata
+        env:
+          RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
+          RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
+        run: |
+          set -euo pipefail
+          jq --arg namespace "https://github.com/${GITHUB_REPOSITORY}/sbom/${RELEASE_TAG}/${RELEASE_SHA}" \
+            '.creationInfo.created = "1970-01-01T00:00:00Z" | .documentNamespace = $namespace' \
+            notify/dist/SBOM.spdx.json > /tmp/SBOM.spdx.json
+          mv /tmp/SBOM.spdx.json notify/dist/SBOM.spdx.json
+
+      - name: Check for existing exact binary provenance
+        id: binary-provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
+          RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+        run: |
+          set -euo pipefail
+          present=true
+          while IFS= read -r name; do
+            if ! gh attestation verify "notify/dist/$name" --repo "$GITHUB_REPOSITORY" \
+              --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
+              present=false
+            fi
+          done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
+          if [ "$RELEASE_IS_PUBLIC" = true ] && [ "$present" != true ]; then
+            echo "public binary provenance is missing or mismatched; refusing to create it" >&2
+            exit 1
+          fi
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Attest binary provenance
+        if: >-
+          needs.publish-gate.outputs.release_is_public != 'true' &&
+          steps.binary-provenance.outputs.present != 'true'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: notify/dist/vaultsync-notify_*
+
+      - name: Check for existing exact binary SBOM attestation
+        id: binary-sbom
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
+          RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+        run: |
+          set -euo pipefail
+          present=true
+          while IFS= read -r name; do
+            if ! gh attestation verify "notify/dist/$name" --repo "$GITHUB_REPOSITORY" \
+              --predicate-type https://spdx.dev/Document/v2.3 \
+              --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
+              --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
+              present=false
+            fi
+          done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
+          if [ "$RELEASE_IS_PUBLIC" = true ] && [ "$present" != true ]; then
+            echo "public binary SBOM attestation is missing or mismatched; refusing to create it" >&2
+            exit 1
+          fi
+          echo "present=$present" >> "$GITHUB_OUTPUT"
+
+      - name: Attest binary SBOM
+        if: >-
+          needs.publish-gate.outputs.release_is_public != 'true' &&
+          steps.binary-sbom.outputs.present != 'true'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-path: notify/dist/vaultsync-notify_*
+          sbom-path: notify/dist/SBOM.spdx.json
+
+  binary-attestation-ready:
+    name: Require Immutable Binary Attestations
+    if: >-
+      always() &&
+      github.event_name == 'workflow_dispatch' &&
+      inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
+      github.actor == github.repository_owner &&
+      github.triggering_actor == github.repository_owner &&
+      needs.publish-safety-policy.result == 'success' &&
+      needs.notify-guard.result == 'success' &&
+      needs.publish-gate.result == 'success' &&
+      needs.image-ready.result == 'success' &&
+      ((needs.publish-gate.outputs.recovery_mode == 'true' &&
+        needs.attest-binaries.result == 'skipped') ||
+       (needs.publish-gate.outputs.recovery_mode != 'true' &&
+        needs.attest-binaries.result == 'success'))
+    needs:
+      - publish-safety-policy
+      - notify-guard
+      - publish-gate
+      - image-ready
+      - attest-binaries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Confirm the only eligible attestation path
+        env:
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
+          ATTESTATION_RESULT: ${{ needs.attest-binaries.result }}
+        run: |
+          set -euo pipefail
+          if [ "$RECOVERY_MODE" = true ]; then
+            test "$ATTESTATION_RESULT" = skipped
+          else
+            test "$ATTESTATION_RESULT" = success
+          fi
 
   release-binaries:
     name: Stage Release Binaries
@@ -512,13 +807,12 @@ jobs:
       - publish-safety-policy
       - notify-guard
       - publish-gate
-      - publish-image
+      - image-ready
+      - binary-attestation-ready
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: write
-      id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -586,79 +880,44 @@ jobs:
             notify/dist/SBOM.spdx.json > /tmp/SBOM.spdx.json
           mv /tmp/SBOM.spdx.json notify/dist/SBOM.spdx.json
 
-      - name: Check for existing exact binary provenance
-        id: binary-provenance
+      - name: Verify exact binary provenance
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
-          RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
-          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
-          present=true
           while IFS= read -r name; do
             if ! gh attestation verify "notify/dist/$name" --repo "$GITHUB_REPOSITORY" \
               --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
               --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
-              present=false
+              echo "immutable binary provenance is missing or mismatched for $name" >&2
+              exit 1
             fi
           done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
-          if { [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; } && [ "$present" != true ]; then
-            echo "immutable binary provenance is missing or mismatched; refusing to create it" >&2
-            exit 1
-          fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
 
-      - name: Attest binary provenance
-        if: >-
-          needs.publish-gate.outputs.release_is_public != 'true' &&
-          needs.publish-gate.outputs.recovery_mode != 'true' &&
-          steps.binary-provenance.outputs.present != 'true'
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
-        with:
-          subject-path: notify/dist/vaultsync-notify_*
-
-      - name: Check for existing exact binary SBOM attestation
-        id: binary-sbom
+      - name: Verify exact binary SBOM attestation
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
-          RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
-          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
-          present=true
           while IFS= read -r name; do
             if ! gh attestation verify "notify/dist/$name" --repo "$GITHUB_REPOSITORY" \
               --predicate-type https://spdx.dev/Document/v2.3 \
               --source-digest "$RELEASE_SHA" --source-ref "refs/tags/${RELEASE_TAG}" \
               --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/docker.yml" >/dev/null 2>&1; then
-              present=false
+              echo "immutable binary SBOM attestation is missing or mismatched for $name" >&2
+              exit 1
             fi
           done < <(jq -r '.binaries[]' "$RELEASE_SPEC")
-          if { [ "$RELEASE_IS_PUBLIC" = true ] || [ "$RECOVERY_MODE" = true ]; } && [ "$present" != true ]; then
-            echo "immutable binary SBOM attestation is missing or mismatched; refusing to create it" >&2
-            exit 1
-          fi
-          echo "present=$present" >> "$GITHUB_OUTPUT"
-
-      - name: Attest binary SBOM
-        if: >-
-          needs.publish-gate.outputs.release_is_public != 'true' &&
-          needs.publish-gate.outputs.recovery_mode != 'true' &&
-          steps.binary-sbom.outputs.present != 'true'
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
-        with:
-          subject-path: notify/dist/vaultsync-notify_*
-          sbom-path: notify/dist/SBOM.spdx.json
 
       - name: Record exact image index and platform digests
         env:
           IMAGE: ${{ needs.publish-gate.outputs.image }}
           VERSION: ${{ needs.publish-gate.outputs.version }}
-          DIGEST: ${{ needs.publish-image.outputs.digest }}
+          DIGEST: ${{ needs.image-ready.outputs.digest }}
         run: |
           set -euo pipefail
           manifest=$(docker buildx imagetools inspect "${IMAGE}@${DIGEST}" --format '{{json .Manifest}}')
@@ -683,7 +942,7 @@ jobs:
       - name: Create deterministic release manifest
         env:
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
-          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.image-ready.outputs.digest }}
         run: |
           ruby <<'RUBY'
           require "digest"
@@ -721,6 +980,7 @@ jobs:
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_VERSION: ${{ needs.publish-gate.outputs.version }}
           RELEASE_IS_PUBLIC: ${{ needs.publish-gate.outputs.release_is_public }}
+          RECOVERY_MODE: ${{ needs.publish-gate.outputs.recovery_mode }}
         run: |
           set -euo pipefail
           resolve_release() {
@@ -755,6 +1015,7 @@ jobs:
               ;;
             null)
               test "$RELEASE_IS_PUBLIC" != true
+              test "$RECOVERY_MODE" != true
               gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --verify-tag \
                 --draft --latest=false --title "vaultsync-notify ${RELEASE_VERSION}" \
                 --notes "Staged helper release. Publication remains blocked until the digest-bound supported-host rollback and post-publication gates succeed."
@@ -803,7 +1064,7 @@ jobs:
       - publish-safety-policy
       - notify-guard
       - publish-gate
-      - publish-image
+      - image-ready
       - release-binaries
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -822,7 +1083,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.publish-gate.outputs.release_tag }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
-          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.image-ready.outputs.digest }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/vaultsync-notify-release
@@ -835,7 +1096,7 @@ jobs:
       - name: Prove published upgrade, rollback, and forward recovery
         env:
           OLD_IMAGE: ${{ needs.publish-gate.outputs.rollback_image }}
-          NEW_IMAGE: ${{ needs.publish-gate.outputs.image }}@${{ needs.publish-image.outputs.digest }}
+          NEW_IMAGE: ${{ needs.publish-gate.outputs.image }}@${{ needs.image-ready.outputs.digest }}
           NEW_COMMIT: ${{ needs.publish-gate.outputs.release_sha }}
           NEW_VERSION: ${{ needs.publish-gate.outputs.version }}
         run: |
@@ -870,7 +1131,7 @@ jobs:
       - publish-safety-policy
       - notify-guard
       - publish-gate
-      - publish-image
+      - image-ready
       - release-binaries
       - rollout-verify
     runs-on: ubuntu-latest
@@ -891,7 +1152,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.publish-gate.outputs.version }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           IMAGE: ${{ needs.publish-gate.outputs.image }}
-          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.image-ready.outputs.digest }}
           ROLLBACK_IMAGE: ${{ needs.publish-gate.outputs.rollback_image }}
         run: |
           set -euo pipefail
@@ -1030,7 +1291,7 @@ jobs:
       - publish-safety-policy
       - notify-guard
       - publish-gate
-      - publish-image
+      - image-ready
       - release-binaries
       - rollout-verify
       - finalize-release
@@ -1061,7 +1322,7 @@ jobs:
           RELEASE_VERSION: ${{ needs.publish-gate.outputs.version }}
           RELEASE_SHA: ${{ needs.publish-gate.outputs.release_sha }}
           IMAGE: ${{ needs.publish-gate.outputs.image }}
-          IMAGE_DIGEST: ${{ needs.publish-image.outputs.digest }}
+          IMAGE_DIGEST: ${{ needs.image-ready.outputs.digest }}
         run: |
           set -euo pipefail
           release_json=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")


### PR DESCRIPTION
## Summary

- resolve draft releases through GraphQL database IDs, then read their canonical REST objects without treating API failures as release absence
- permit a narrowly scoped owner recovery dispatch from the current `main` only when it binds to the failed tag-bound publication run, source tag, source commit, failed step, and skipped rollout/finalization jobs
- check out the immutable source commit for every publication-content job and prohibit image, provenance, and SBOM-attestation writes during recovery
- serialize normal and recovery dispatches by release tag and extend the executable publication safety policy

## Failed publication state being recovered

- source tag: `notify-v2.0.0`
- source commit: `664a896c5c14b86a806f8fa47b0d900b32649bff`
- failed run: `29324314809`
- failed step: `Stage Release Binaries / Create or verify the exact draft release and assets`
- root cause: GitHub created draft release `353712477`, but the REST release-by-tag endpoint returned 404 for that draft
- image publication, vulnerability/secret scan, SPDX SBOM, image provenance, image SBOM attestation, reproducible binary build, binary scan, binary provenance, and binary SBOM attestations completed successfully before the failure
- rollout, release finalization, and public verification were skipped; the draft has no assets and remains unpublished

## Safety invariants

- the existing source tag is never moved or replaced
- main-ref recovery requires an owner-triggered failed run whose tag, head SHA, workflow path, failed job/step, successful image job, and skipped downstream jobs all match
- the recovery workflow definition must be the freshly fetched, verified `origin/main`
- `notify/release.json` must be byte-identical between the recovery workflow commit and the source tag
- a recovery aborts if the exact version image or any tag-/commit-/workflow-bound image or binary attestation is missing
- public release retries remain read-only; existing assets are reused only on exact SHA-256 equality
- no `latest` tag is read or moved by the workflow
- upload, download, and roundtrip product evidence remain unset

## Validation

- `ruby -c .github/scripts/notify-publish-safety.rb`
- `ruby .github/scripts/notify-publish-safety.rb`
- Actionlint 1.7.12 with ShellCheck 0.10.0
- Zizmor 1.26.1 offline: no findings
- `cd notify && go test ./... -count=1`
- Trivy 0.70.0 filesystem vulnerability/secret scan: 0 HIGH/CRITICAL findings
- exact recovery-gate dry-run accepted run `29324314809` and rejected an unrelated successful run
- GraphQL release-ID resolver found draft `353712477` and failed closed on a simulated API/repository failure
- all five Go 1.26.5 source-tag binaries reproduced byte-identically and verified against existing provenance and SPDX attestations
- image `sha256:9718196b97afb6aee43c4578c1fb130a7874c34115f04b22c690b7d243667fc7` verified against existing provenance and SPDX attestations
- GHCR `latest` remained `sha256:90d4a56b0e7d5bf90541157c13b0265198df6893accf8e64b228587996e41fa4`

## Compatibility and scope

This changes only publication orchestration and its executable safety policy. Helper runtime behavior, wire formats, Decision 024, credentials, pairing, namespace handling, existing-user behavior, upload/download/roundtrip semantics, backup/versioning/conflict/tombstone behavior, and Relay/App runtime are unchanged.
