### PR TITLE
fix(notify): keep recovery gate read-only

### DIFF
--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -182,6 +182,10 @@ assert_policy(jobs.fetch("build-without-push").fetch("if") == "github.event_name
               "the no-push build must be the only image build on normal events")
 assert_policy(jobs.fetch("publish-gate").fetch("if") == "github.event_name == 'workflow_dispatch'",
               "the read-only publish gate must run only for manual dispatch")
+assert_policy(jobs.fetch("publish-gate").fetch("permissions") == {
+                "actions" => "read",
+                "contents" => "read"
+              }, "publish-gate must receive only run-history and repository read permissions")
 source_security_steps = steps(jobs.fetch("publish-gate")).select do |step|
   step.fetch("uses", "").start_with?("aquasecurity/trivy-action@") &&
     step.fetch("with", {}).fetch("scan-ref", "") == "notify"
@@ -511,6 +515,8 @@ assert_policy(jobs.fetch("publish-gate").fetch("outputs").fetch("release_is_publ
               gate_text.include?('case $release_type in') &&
               gate_text.include?('release_is_public=true') &&
               gate_text.include?('release_is_public=$release_is_public') &&
+              gate_text.include?('[ "$recovery_mode" = true ] && [ "$release_type" = null ]') &&
+              gate_text.include?("Draft visibility deferred to the exact recovery staging gate.") &&
               gate_text.include?('actions/runs/${RECOVERY_RUN_ID}') &&
               gate_text.include?('Create or verify the exact draft release and assets') &&
               gate_text.include?('git checkout --detach "$resolved"') &&

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,6 +132,9 @@ jobs:
       - notify-guard
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
     outputs:
       version: ${{ steps.validate.outputs.version }}
       release_tag: ${{ steps.validate.outputs.release_tag }}
@@ -257,9 +260,12 @@ jobs:
             *) exit 1 ;;
           esac
 
-          if [ "$recovery_mode" = true ]; then
-            test "$release_type" = object
-            test "$(jq -r .isDraft <<<"$release_json")" = true
+          if [ "$recovery_mode" = true ] && [ "$release_type" = null ]; then
+            # GitHub exposes draft releases only to tokens with push access. Keep
+            # this gate read-only; release-binaries resolves the exact draft with
+            # its isolated contents:write token and refuses to recreate a missing
+            # draft during recovery before performing any release mutation.
+            echo "Draft visibility deferred to the exact recovery staging gate."
           fi
 
           manifest_digest=$(sha256sum "$RELEASE_SPEC" | awk '{print $1}')


### PR DESCRIPTION
## Summary

- grant the owner publication gate only `actions: read` in addition to its existing `contents: read`, so it can validate the exact failed workflow run and jobs;
- keep the gate free of every write permission and accept that a read-only token cannot enumerate a draft release;
- defer an invisible draft to the existing `contents: write` staging resolver, which requires exactly one matching release and refuses to recreate a missing draft during recovery before any release mutation.

## Failure evidence

Recovery run `29332225420` completed its notify guard and publication safety policy, then failed closed in `Owner Publish Gate`. Every registry, image-selection, binary, draft-staging, rollout, finalization, and public-verification job was skipped, so the failed recovery attempt changed no release state.

The exact tag, source commit, failed source run, draft, rollback release, image digest, platform digests, attached image attestations, and five binary attestations were independently reverified before this change. GitHub's release API exposes drafts only to callers with push access, while this gate intentionally remains read-only.

## Security and compatibility

- no write, OIDC, attestation, package, or release permission is added to the gate;
- the recovery-only image verifier remains `packages: read`;
- missing or mismatched recovery drafts still abort in the write-isolated staging job and cannot be recreated;
- normal tag publication, public read-only retries, helper runtime, wire formats, pairing, namespace behavior, and Decision 024 are unchanged;
- existing installations remain dormant without explicit operator configuration;
- upload, download, and roundtrip product evidence remain unset.

## Verification

- `ruby -c .github/scripts/notify-publish-safety.rb`
- `ruby .github/scripts/notify-publish-safety.rb`
- `actionlint` 1.7.12 with ShellCheck 0.10.0
- `zizmor --offline` 1.26.1: no findings
- `cd notify && GOTOOLCHAIN=local go test ./... -count=1`
- Trivy 0.70.0 filesystem vulnerability and secret scan: no HIGH/CRITICAL vulnerabilities or secret findings
- `git diff --check`

## Release truth

Helper publication remains incomplete until a new exact-main recovery run passes immutable image and binary verification, draft staging, published upgrade/rollback/forward-recovery proof, finalization, and public read-only verification.
