### PR TITLE
fix(notify): continue verified recovery chain

### DIFF
--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -18,6 +18,7 @@ NORMAL_ONLY_JOBS = %w[publish-image attest-binaries].freeze
 RECOVERY_ONLY_JOBS = %w[recover-image].freeze
 DUAL_PATH_JOBS = %w[release-binaries rollout-verify finalize-release verify-published].freeze
 AGGREGATE_JOBS = %w[image-ready binary-attestation-ready].freeze
+SEQUENCED_PUBLICATION_JOBS = %w[release-binaries rollout-verify finalize-release].freeze
 DISPATCH_JOBS = (NORMAL_ONLY_JOBS + RECOVERY_ONLY_JOBS + DUAL_PATH_JOBS + AGGREGATE_JOBS).freeze
 MANUAL_JOBS = (DISPATCH_JOBS + ["publish-gate"]).freeze
 COMMON_GATE_FRAGMENTS = [
@@ -448,10 +449,37 @@ end
 
 DUAL_PATH_JOBS.each do |name|
   condition = jobs.fetch(name).fetch("if")
+  assert_policy(condition.include?("always()"),
+                "#{name} must evaluate explicit predecessor state after a skipped alternate path")
   (NORMAL_GATE_FRAGMENTS + RECOVERY_GATE_FRAGMENTS).each do |fragment|
     assert_policy(condition.include?(fragment), "#{name} is missing dual-path gate #{fragment}")
   end
 end
+
+SEQUENCED_PUBLICATION_JOBS.each do |name|
+  condition = jobs.fetch(name).fetch("if")
+  jobs.fetch(name).fetch("needs").each do |predecessor|
+    result_gate = "needs.#{predecessor}.result == 'success'"
+    assert_policy(condition.include?(result_gate),
+                  "#{name} must fail closed unless #{predecessor} succeeded")
+  end
+end
+
+verify_predecessors = {
+  "PUBLISH_SAFETY_RESULT" => "${{ needs.publish-safety-policy.result }}",
+  "NOTIFY_GUARD_RESULT" => "${{ needs.notify-guard.result }}",
+  "PUBLISH_GATE_RESULT" => "${{ needs.publish-gate.result }}",
+  "IMAGE_READY_RESULT" => "${{ needs.image-ready.result }}",
+  "RELEASE_BINARIES_RESULT" => "${{ needs.release-binaries.result }}",
+  "ROLLOUT_RESULT" => "${{ needs.rollout-verify.result }}",
+  "FINALIZE_RESULT" => "${{ needs.finalize-release.result }}"
+}.freeze
+verify_guard = steps(jobs.fetch("verify-published")).find do |step|
+  step["name"] == "Require every publication predecessor to succeed"
+end
+assert_policy(!verify_guard.nil? && verify_guard.fetch("env") == verify_predecessors &&
+              verify_guard.fetch("run").include?('test "$result" = success'),
+              "public verification must turn every failed or skipped predecessor into a workflow failure")
 
 AGGREGATE_JOBS.each do |name|
   condition = jobs.fetch(name).fetch("if")

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -803,12 +803,18 @@ jobs:
   release-binaries:
     name: Stage Release Binaries
     if: >-
+      always() &&
       github.event_name == 'workflow_dispatch' &&
       ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
        (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
-      github.triggering_actor == github.repository_owner
+      github.triggering_actor == github.repository_owner &&
+      needs.publish-safety-policy.result == 'success' &&
+      needs.notify-guard.result == 'success' &&
+      needs.publish-gate.result == 'success' &&
+      needs.image-ready.result == 'success' &&
+      needs.binary-attestation-ready.result == 'success'
     needs:
       - publish-safety-policy
       - notify-guard
@@ -1060,12 +1066,18 @@ jobs:
   rollout-verify:
     name: Published Helper Rollout
     if: >-
+      always() &&
       github.event_name == 'workflow_dispatch' &&
       ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
        (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
-      github.triggering_actor == github.repository_owner
+      github.triggering_actor == github.repository_owner &&
+      needs.publish-safety-policy.result == 'success' &&
+      needs.notify-guard.result == 'success' &&
+      needs.publish-gate.result == 'success' &&
+      needs.image-ready.result == 'success' &&
+      needs.release-binaries.result == 'success'
     needs:
       - publish-safety-policy
       - notify-guard
@@ -1127,12 +1139,19 @@ jobs:
   finalize-release:
     name: Finalize Helper Release
     if: >-
+      always() &&
       github.event_name == 'workflow_dispatch' &&
       ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
        (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
       inputs.confirmation == 'PUBLISH_NOTIFY_RELEASE' &&
       github.actor == github.repository_owner &&
-      github.triggering_actor == github.repository_owner
+      github.triggering_actor == github.repository_owner &&
+      needs.publish-safety-policy.result == 'success' &&
+      needs.notify-guard.result == 'success' &&
+      needs.publish-gate.result == 'success' &&
+      needs.image-ready.result == 'success' &&
+      needs.release-binaries.result == 'success' &&
+      needs.rollout-verify.result == 'success'
     needs:
       - publish-safety-policy
       - notify-guard
@@ -1287,6 +1306,7 @@ jobs:
   verify-published:
     name: Verify Published Helper
     if: >-
+      always() &&
       github.event_name == 'workflow_dispatch' &&
       ((github.ref_type == 'tag' && inputs.release_tag == github.ref_name && inputs.recovery_run_id == '') ||
        (github.ref == 'refs/heads/main' && inputs.recovery_run_id != '')) &&
@@ -1307,6 +1327,29 @@ jobs:
       contents: read
       packages: read
     steps:
+      - name: Require every publication predecessor to succeed
+        env:
+          PUBLISH_SAFETY_RESULT: ${{ needs.publish-safety-policy.result }}
+          NOTIFY_GUARD_RESULT: ${{ needs.notify-guard.result }}
+          PUBLISH_GATE_RESULT: ${{ needs.publish-gate.result }}
+          IMAGE_READY_RESULT: ${{ needs.image-ready.result }}
+          RELEASE_BINARIES_RESULT: ${{ needs.release-binaries.result }}
+          ROLLOUT_RESULT: ${{ needs.rollout-verify.result }}
+          FINALIZE_RESULT: ${{ needs.finalize-release.result }}
+        run: |
+          set -euo pipefail
+          for result in \
+            "$PUBLISH_SAFETY_RESULT" \
+            "$NOTIFY_GUARD_RESULT" \
+            "$PUBLISH_GATE_RESULT" \
+            "$IMAGE_READY_RESULT" \
+            "$RELEASE_BINARIES_RESULT" \
+            "$ROLLOUT_RESULT" \
+            "$FINALIZE_RESULT"
+          do
+            test "$result" = success
+          done
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ needs.publish-gate.outputs.release_sha }}


### PR DESCRIPTION
## Summary

- evaluate every dual-path publication job after the recovery-only binary-attestation job is intentionally skipped;
- require every direct predecessor to succeed before draft staging, published rollout, or release finalization;
- turn any failed or skipped publication predecessor into a failing final read-only verification job.

## Failure evidence

Recovery run `29334987744` was bound to `main@ba91d4d72785b5101bf2c53d446a6ebcea8b3d72`. Publication safety, notify tests, the owner gate, immutable image recovery, image selection, and binary-attestation selection succeeded. The tag-only `Attest Release Binaries` job was correctly skipped, but GitHub propagated that skip through the implicit job-level success condition, so draft staging, rollout, finalization, and public verification were all skipped.

The workflow reported success, but release draft `353712477` remained unpublished with zero assets and its staging body unchanged. No registry, draft, release, rollout, or public-state mutation occurred in this recovery run.

## Security and compatibility

- every job with draft or release write access remains gated by exact owner, ref, confirmation, and explicit direct-predecessor success checks;
- the final public verifier remains read-only and now fails the workflow if any required predecessor failed or was skipped;
- no permission, tag, image, binary, attestation, release-note, helper-runtime, wire-format, pairing, namespace, or Decision 024 behavior changes;
- existing installations remain dormant without explicit operator configuration;
- upload, download, and roundtrip product evidence remain unset.

## Verification

- `ruby -c .github/scripts/notify-publish-safety.rb`
- `ruby .github/scripts/notify-publish-safety.rb`
- `actionlint` 1.7.12 with ShellCheck 0.10.0
- `zizmor --offline .github/workflows/docker.yml` 1.26.1: no findings
- `cd notify && GOTOOLCHAIN=local go test ./... -count=1`
- Trivy 0.70.0 filesystem vulnerability and secret scan: no HIGH/CRITICAL vulnerabilities or secret findings
- `git diff --check`

## Release truth

Helper publication remains incomplete until a new exact-main recovery run passes immutable image and binary verification, draft staging, the published upgrade/rollback/forward-recovery proof, finalization, and public read-only verification.
