### PR TITLE
fix(notify): read draft assets by release ID

### DIFF
--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -413,6 +413,9 @@ assert_policy(finalize_text.include?('test "$release_is_draft" = true') &&
               finalize_text.include?("gh api graphql") &&
               finalize_text.include?("databaseId") &&
               finalize_text.include?('releases/${release_id}') &&
+              finalize_text.include?('releases/assets/${evidence_id}') &&
+              finalize_text.include?('Accept: application/octet-stream') &&
+              !finalize_text.include?('gh release download "$RELEASE_TAG"') &&
               finalize_text.include?("|| return 1") &&
               public_branch && public_exit && release_edit && public_exit < release_edit,
               "rollout evidence and release finalization must be read-only once public")
@@ -522,6 +525,16 @@ end
 
 assert_policy((%w[release-binaries image-ready] - jobs.fetch("rollout-verify").fetch("needs")).empty?,
               "published rollout must follow complete draft staging and immutable image selection")
+rollout_text = flattened_step_text(jobs.fetch("rollout-verify"))
+assert_policy(rollout_text.include?("gh api graphql") &&
+              rollout_text.include?("databaseId") &&
+              rollout_text.include?('releases/${release_id}') &&
+              rollout_text.include?('releases/assets/${asset_id}') &&
+              rollout_text.include?('Accept: application/octet-stream') &&
+              rollout_text.include?('test "$matches" = 1') &&
+              rollout_text.include?('^sha256:[0-9a-f]{64}$') &&
+              !rollout_text.include?('gh release download "$RELEASE_TAG"'),
+              "published rollout must resolve draft assets by validated release and asset IDs")
 assert_policy((%w[rollout-verify image-ready] - jobs.fetch("finalize-release").fetch("needs")).empty?,
               "release finalization must follow the published rollback proof")
 assert_policy((%w[finalize-release image-ready] - jobs.fetch("verify-published").fetch("needs")).empty?,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1104,8 +1104,48 @@ jobs:
           IMAGE_DIGEST: ${{ needs.image-ready.outputs.digest }}
         run: |
           set -euo pipefail
+          resolve_release() {
+            repository_owner=${GITHUB_REPOSITORY%%/*}
+            repository_name=${GITHUB_REPOSITORY#*/}
+            # GraphQL includes drafts, unlike the REST release-by-tag endpoint.
+            # Keep the query literal so shell expansion cannot alter its variables.
+            # shellcheck disable=SC2016
+            lookup=$(gh api graphql \
+              -F owner="$repository_owner" -F name="$repository_name" -F tag="$RELEASE_TAG" \
+              -f query='query($owner: String!, $name: String!, $tag: String!) {
+                repository(owner: $owner, name: $name) {
+                  release(tagName: $tag) { databaseId }
+                }
+              }') || return 1
+            jq -e '.data.repository != null and ((.errors // []) | length == 0)' <<<"$lookup" >/dev/null || return 1
+            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || return 1
+            printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || return 1
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || return 1
+          }
+
+          release_json=$(resolve_release)
+          test "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG"
+          test "$(jq -r .prerelease <<<"$release_json")" = false
+          while IFS= read -r existing_name; do
+            jq -e --arg name "$existing_name" '.release_assets | index($name) != null' "$RELEASE_SPEC" >/dev/null
+          done < <(jq -r '.assets[].name' <<<"$release_json")
+
           mkdir -p /tmp/vaultsync-notify-release
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --dir /tmp/vaultsync-notify-release
+          mapfile -t required_names < <(
+            jq -r '.release_assets[] | select(. != "ROLLOUT-EVIDENCE.txt")' "$RELEASE_SPEC"
+          )
+          for name in "${required_names[@]}"; do
+            matches=$(jq -r --arg name "$name" '[.assets[] | select(.name == $name)] | length' <<<"$release_json")
+            test "$matches" = 1
+            asset_id=$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .id' <<<"$release_json")
+            asset_digest=$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .digest' <<<"$release_json")
+            printf '%s\n' "$asset_id" | grep -Eq '^[1-9][0-9]*$'
+            printf '%s\n' "$asset_digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+            target="/tmp/vaultsync-notify-release/$name"
+            gh api --method GET -H 'Accept: application/octet-stream' \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "$target"
+            test "sha256:$(sha256sum "$target" | awk '{print $1}')" = "$asset_digest"
+          done
           (cd /tmp/vaultsync-notify-release && sha256sum -c SHA256SUMS)
           jq -e --arg sha "$RELEASE_SHA" --arg digest "$IMAGE_DIGEST" \
             '.source_commit == $sha and .image_index_digest == $digest' \
@@ -1213,7 +1253,10 @@ jobs:
           if [ -n "$evidence_digest" ]; then
             rm -rf /tmp/existing-rollout
             mkdir -p /tmp/existing-rollout
-            gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$evidence_name" --dir /tmp/existing-rollout
+            evidence_id=$(jq -r --arg name "$evidence_name" '.assets[] | select(.name == $name) | .id' <<<"$release_json")
+            printf '%s\n' "$evidence_id" | grep -Eq '^[1-9][0-9]*$'
+            gh api --method GET -H 'Accept: application/octet-stream' \
+              "repos/${GITHUB_REPOSITORY}/releases/assets/${evidence_id}" > "/tmp/existing-rollout/$evidence_name"
             test "sha256:$(sha256sum "/tmp/existing-rollout/$evidence_name" | awk '{print $1}')" = "$evidence_digest"
             grep -qx "source_commit=${RELEASE_SHA}" /tmp/existing-rollout/$evidence_name
             grep -qx "release_tag=${RELEASE_TAG}" /tmp/existing-rollout/$evidence_name


### PR DESCRIPTION
## Summary

- resolve staged helper releases through GraphQL so a private draft is visible before finalization;
- download every required pre-rollout asset through its validated numeric REST asset ID and verify its server-recorded SHA-256 locally;
- keep finalization retries draft-aware when rollout evidence was uploaded before a later failure.

## Failure evidence

Recovery publication run `29339718813` was bound to `main@f3a823d5b9c29764c2e89e90c23254736e4598c7`. Policy, notify, owner, immutable image, binary attestation, and binary staging gates succeeded. The private draft received exactly nine expected pre-rollout assets with verified digests.

`Published Helper Rollout` then failed in its first read-only step because `gh release download notify-v2.0.0` uses a tag-based REST lookup that does not see draft releases. No helper container, upgrade, downgrade, forward recovery, rollout evidence, finalization, or public release occurred. Draft `353712477` remains private with those nine assets.

## Security and compatibility

- rollout permissions remain `contents: read`; finalization permissions and every owner/ref/predecessor gate are unchanged;
- release IDs and asset IDs must be positive decimal values, every asset name must be in the immutable release specification, every API digest must be canonical SHA-256, and every downloaded byte stream is rehashed before use;
- the safety policy forbids reintroducing tag-based draft downloads in rollout or finalization retry paths;
- no image, tag, binary, attestation, release note, runtime, wire format, pairing, namespace, Decision 024, or existing-user behavior changes;
- upload, download, and roundtrip product evidence remain unset.

## Verification

- `ruby -c .github/scripts/notify-publish-safety.rb`
- `ruby .github/scripts/notify-publish-safety.rb`
- `cd notify && GOTOOLCHAIN=local go test ./... -count=1`
- Actionlint 1.7.12 with ShellCheck 0.10.0
- `zizmor --offline .github/workflows/docker.yml` 1.26.1: no findings
- Trivy 0.70.0 filesystem vulnerability and secret scan: no HIGH/CRITICAL vulnerabilities or secret findings
- live read-only proof against draft `353712477`: nine asset-ID downloads, API/local digest equality, all five `SHA256SUMS` checks, and exact manifest source/image binding
- `git diff --check`

## Release truth

Helper publication remains incomplete. The release is still a private draft and the real published-image upgrade, rollback, forward-recovery, finalization, and public verification gates must still succeed.