### PR TITLE
fix(notify): allow staged rollout verification

### DIFF
--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -13,7 +13,7 @@ DOCKERFILE_PATH = File.join(ROOT, "notify/Dockerfile")
 INSTALL_PATH = File.join(ROOT, "notify/scripts/install.sh")
 COMPOSE_PATH = File.join(ROOT, "notify/docker-compose.yml")
 PINNED_ACTION = /\A[^@]+@[0-9a-f]{40}\z/
-WRITE_JOBS = %w[publish-image attest-binaries release-binaries finalize-release].freeze
+WRITE_JOBS = %w[publish-image attest-binaries release-binaries rollout-verify finalize-release].freeze
 NORMAL_ONLY_JOBS = %w[publish-image attest-binaries].freeze
 RECOVERY_ONLY_JOBS = %w[recover-image].freeze
 DUAL_PATH_JOBS = %w[release-binaries rollout-verify finalize-release verify-published].freeze
@@ -200,7 +200,7 @@ write_jobs = jobs.select do |_name, job|
   job.fetch("permissions", {}).value?("write")
 end.keys.sort
 assert_policy(write_jobs == WRITE_JOBS.sort,
-              "only normal publication, draft staging, and finalization jobs may receive write permissions")
+              "only normal publication, draft staging, draft rollout, and finalization jobs may receive write permissions")
 assert_policy(jobs.fetch("publish-image").fetch("permissions") == {
                 "contents" => "read",
                 "packages" => "write",
@@ -218,6 +218,10 @@ assert_policy(jobs.fetch("attest-binaries").fetch("permissions") == {
               }, "attest-binaries permissions changed")
 assert_policy(jobs.fetch("release-binaries").fetch("permissions") == { "contents" => "write" },
               "release-binaries must receive only draft-asset write permission")
+assert_policy(jobs.fetch("rollout-verify").fetch("permissions") == {
+                "contents" => "write",
+                "packages" => "read"
+              }, "rollout-verify must receive only draft visibility and registry read permissions")
 assert_policy(jobs.fetch("finalize-release").fetch("permissions") == { "contents" => "write" },
               "finalize-release permissions changed")
 %w[image-ready binary-attestation-ready].each do |name|
@@ -566,11 +570,19 @@ assert_policy(rollout_text.include?("gh api graphql") &&
               rollout_text.include?('releases/assets/${asset_id}') &&
               rollout_text.include?('Accept: application/octet-stream') &&
               rollout_text.include?('test "$matches" = 1') &&
+              rollout_text.include?('test "$(jq -r .draft <<<"$release_json")" = true') &&
               rollout_text.include?('^sha256:[0-9a-f]{64}$') &&
               rollout_text.include?("binary_sbom") &&
               rollout_text.include?("image_digests_sha256") &&
               !rollout_text.include?('gh release download "$RELEASE_TAG"'),
               "published rollout must resolve draft assets by validated release and asset IDs")
+rollout_mutations = [
+  "gh release ", "mutation(", "mutation ",
+  "--method POST", "--method PATCH", "--method PUT", "--method DELETE",
+  "-X POST", "-X PATCH", "-X PUT", "-X DELETE"
+]
+assert_policy(rollout_mutations.none? { |fragment| rollout_text.include?(fragment) },
+              "published rollout may use draft visibility but must remain release-read-only")
 assert_policy((%w[rollout-verify image-ready] - jobs.fetch("finalize-release").fetch("needs")).empty?,
               "release finalization must follow the published rollback proof")
 assert_policy((%w[finalize-release image-ready] - jobs.fetch("verify-published").fetch("needs")).empty?,

--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -566,6 +566,7 @@ assert_policy((%w[release-binaries image-ready] - jobs.fetch("rollout-verify").f
 rollout_text = flattened_step_text(jobs.fetch("rollout-verify"))
 assert_policy(rollout_text.include?("gh api graphql") &&
               rollout_text.include?("databaseId") &&
+              rollout_text.include?(%q{release_id=$(jq -er '.data.repository.release.databaseId // empty' <<<"$lookup")}) &&
               rollout_text.include?('releases/${release_id}') &&
               rollout_text.include?('releases/assets/${asset_id}') &&
               rollout_text.include?('Accept: application/octet-stream') &&

--- a/.github/scripts/notify-publish-safety.rb
+++ b/.github/scripts/notify-publish-safety.rb
@@ -570,7 +570,9 @@ assert_policy(rollout_text.include?("gh api graphql") &&
               rollout_text.include?('releases/assets/${asset_id}') &&
               rollout_text.include?('Accept: application/octet-stream') &&
               rollout_text.include?('test "$matches" = 1') &&
-              rollout_text.include?('test "$(jq -r .draft <<<"$release_json")" = true') &&
+              rollout_text.include?('release_is_draft=$(jq -r .draft <<<"$release_json")') &&
+              rollout_text.include?('case $release_is_draft in') &&
+              rollout_text.include?('true|false)') &&
               rollout_text.include?('^sha256:[0-9a-f]{64}$') &&
               rollout_text.include?("binary_sbom") &&
               rollout_text.include?("image_digests_sha256") &&

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1160,7 +1160,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      contents: read
+      # GitHub exposes draft releases only to tokens with push access. The
+      # publish-safety policy confines this token to the read-only API calls
+      # below and rejects release mutation commands in this job.
+      contents: write
       packages: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -1189,15 +1192,31 @@ jobs:
                 repository(owner: $owner, name: $name) {
                   release(tagName: $tag) { databaseId }
                 }
-              }') || return 1
-            jq -e '.data.repository != null and ((.errors // []) | length == 0)' <<<"$lookup" >/dev/null || return 1
-            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || return 1
-            printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$' || return 1
-            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || return 1
+              }') || {
+                echo "::error::Draft release GraphQL lookup failed." >&2
+                return 1
+              }
+            jq -e '.data.repository != null and ((.errors // []) | length == 0)' <<<"$lookup" >/dev/null || {
+              echo "::error::Draft release GraphQL response was invalid." >&2
+              return 1
+            }
+            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || {
+              echo "::error::Draft release database ID could not be parsed." >&2
+              return 1
+            }
+            if ! printf '%s\n' "$release_id" | grep -Eq '^[1-9][0-9]*$'; then
+              echo "::error::Draft release is not visible to the rollout token." >&2
+              return 1
+            fi
+            gh api "repos/${GITHUB_REPOSITORY}/releases/${release_id}" || {
+              echo "::error::Draft release metadata could not be read." >&2
+              return 1
+            }
           }
 
           release_json=$(resolve_release)
           test "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG"
+          test "$(jq -r .draft <<<"$release_json")" = true
           test "$(jq -r .prerelease <<<"$release_json")" = false
           while IFS= read -r existing_name; do
             jq -e --arg name "$existing_name" '.release_assets | index($name) != null' "$RELEASE_SPEC" >/dev/null

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1200,7 +1200,7 @@ jobs:
               echo "::error::Draft release GraphQL response was invalid." >&2
               return 1
             }
-            release_id=$(jq -r '.data.repository.release.databaseId // empty' <<<"$lookup") || {
+            release_id=$(jq -er '.data.repository.release.databaseId // empty' <<<"$lookup") || {
               echo "::error::Draft release database ID could not be parsed." >&2
               return 1
             }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1216,7 +1216,14 @@ jobs:
 
           release_json=$(resolve_release)
           test "$(jq -r .tag_name <<<"$release_json")" = "$RELEASE_TAG"
-          test "$(jq -r .draft <<<"$release_json")" = true
+          release_is_draft=$(jq -r .draft <<<"$release_json")
+          case $release_is_draft in
+            true|false) ;;
+            *)
+              echo "::error::Release draft state was invalid." >&2
+              exit 1
+              ;;
+          esac
           test "$(jq -r .prerelease <<<"$release_json")" = false
           while IFS= read -r existing_name; do
             jq -e --arg name "$existing_name" '.release_assets | index($name) != null' "$RELEASE_SPEC" >/dev/null


### PR DESCRIPTION
Summary
- grant the owner-gated rollout job the contents permission required to see private draft releases
- validate the exact release state and emit explicit resolution errors
- statically reject release commands, GraphQL mutations, and mutating REST methods from the rollout job

Root cause
- both publication attempts failed before any asset download because the contents:read job token could not resolve the private draft
- GitHub documents draft listings as visible only with push access
- staging with contents:write resolved the same draft successfully, while the rollout job failed twice with contents:read

Security and release truth
- permission remains job-local and the exact permission map is policy-enforced
- checkout credentials remain non-persistent
- the job performs only validated GraphQL queries and REST GET asset downloads
- private-draft verification and idempotent post-public recovery remain supported without release mutation
- helper rollout, finalization, and public release have not yet run

Verification
- ruby -c .github/scripts/notify-publish-safety.rb
- ruby .github/scripts/notify-publish-safety.rb
- jq -er missing/present release-ID exit-status regression
- /tmp/actionlint-1.7.12/actionlint -shellcheck=/tmp/shellcheck-v0.10.0/shellcheck .github/workflows/docker.yml
- /tmp/vaultsync-pr116-tools/zizmor/zizmor --min-severity medium .github/workflows/docker.yml
- cd notify && go test ./... -count=1
- git diff --check