### PR TITLE
docs(community): add security policy, contributing guide, and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [umut.erdem@protonmail.com](mailto:umut.erdem@protonmail.com). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,10 +29,10 @@ An honest picture of what you can build where:
 
 ```bash
 # Server helper (its own Go module)
-cd notify && go test ./... && go vet ./...
+(cd notify && go test ./... && go vet ./...)
 
 # Sync bridge (applies the Syncthing patches first; ~1 min, starts real Syncthing instances)
-cd go && make patch && go test -tags noassets ./bridge
+(cd go && make patch && go test -tags noassets ./bridge)
 ```
 
 `gofmt` is enforced by CI for both modules.
@@ -40,10 +40,10 @@ cd go && make patch && go test -tags noassets ./bridge
 **iOS app — macOS only**, with Xcode 26+, XcodeGen, gomobile, and Make:
 
 ```bash
-cd go && make patch && make xcframework   # builds the embedded sync engine (~160 MB)
-cd ios && xcodegen generate
-xcodebuild test -project VaultSync.xcodeproj -scheme VaultSync \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' CODE_SIGNING_ALLOWED=NO
+(cd go && make patch && make xcframework)   # builds the embedded sync engine (~160 MB)
+(cd ios && xcodegen generate)
+(cd ios && xcodebuild test -project VaultSync.xcodeproj -scheme VaultSync \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' CODE_SIGNING_ALLOWED=NO)
 ```
 
 The full build, signing, and test guide is [`docs/setup.md`](docs/setup.md). If you only touch the Go side, you don't need a Mac at all.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing to VaultSync
+
+Thank you for considering a contribution — it genuinely helps. VaultSync is maintained by one person, and community input is one of the best ways this project gets better.
+
+One thing shapes everything here: VaultSync syncs people's personal notes across their devices. A bug in the wrong place doesn't crash a demo — it can damage someone's vault. That's why a few areas move deliberately slowly (explained below), and why your patience with the process is appreciated.
+
+## Contributions that help the most
+
+- **Bug reports** — especially with the helper's self-check attached (`vaultsync-notify --doctor`), your iOS and VaultSync versions, and your server's Syncthing version.
+- **Documentation improvements** — setup and troubleshooting docs get better with every real-world deployment they describe.
+- **Deployment experience** — running the helper on a NAS (Synology, QNAP), via Docker Compose, or on unusual setups? Notes about what worked and what didn't are valuable.
+- **Testing on different platforms** — the helper ships for Linux, macOS, and Windows; coverage across them is hard for one person.
+- **Translation review** — the app is localized in English, German, Spanish, and Simplified Chinese. Native-speaker review of existing strings is very welcome.
+
+## Please open an issue first
+
+For anything beyond a trivial fix (a typo, a broken link, an obvious one-liner), **please open an issue before writing code**. Two honest reasons:
+
+1. Review time is limited. An issue first makes sure your work fits the project's direction *before* you invest in it — nobody enjoys a rejected PR that took a weekend.
+2. Central areas are governed by binding decision records in [`docs/decisions/`](docs/decisions/): the wire contracts, the diagnostics protocol, and the data-safety invariants are frozen. Changing them requires a new decision record and maintainer approval. That's not "hands off" — it means: open an issue and we design the change together.
+
+Reading the decision records before proposing a change in those areas will save you time; each one explains *why* the constraint exists.
+
+## Development setup
+
+An honest picture of what you can build where:
+
+**Go components — Linux or macOS, Go 1.26+:**
+
+```bash
+# Server helper (its own Go module)
+cd notify && go test ./... && go vet ./...
+
+# Sync bridge (applies the Syncthing patches first; ~1 min, starts real Syncthing instances)
+cd go && make patch && go test -tags noassets ./bridge
+```
+
+`gofmt` is enforced by CI for both modules.
+
+**iOS app — macOS only**, with Xcode 26+, XcodeGen, gomobile, and Make:
+
+```bash
+cd go && make patch && make xcframework   # builds the embedded sync engine (~160 MB)
+cd ios && xcodegen generate
+xcodebuild test -project VaultSync.xcodeproj -scheme VaultSync \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' CODE_SIGNING_ALLOWED=NO
+```
+
+The full build, signing, and test guide is [`docs/setup.md`](docs/setup.md). If you only touch the Go side, you don't need a Mac at all.
+
+## Pull request conventions
+
+- **PR titles must be Conventional Commits** — CI enforces this, and since PRs are squash-merged, your title becomes the commit subject on `main`. Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `perf`, `build`, `style`, `revert`. Example: `fix(notify): handle missing config path`.
+- **Small, focused PRs** — one concern per PR reviews faster and merges sooner.
+- **Behavior changes need tests.** Bug fixes should include a regression test that references the issue number.
+- User-facing changes get a `CHANGELOG.md` entry under `[Unreleased]`.
+
+## Localization
+
+Every user-facing string ships in four languages: `en`, `de`, `es`, `zh-Hans`.
+
+- The **English literal string is the key**. A key missing from any of the four `Localizable.strings` files silently falls back to English.
+- All four files must contain **identical key sets** — CI checks this (Strings Key Parity), and you can run it locally: `ios/scripts/strings-key-parity.sh`.
+- German uses the informal du-form, matching the existing strings.
+
+## Security issues
+
+Please **do not** open a public issue for anything security-relevant — use the private channels described in [SECURITY.md](SECURITY.md) instead.
+
+## Code of conduct & license
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Contributions are licensed under [MPL-2.0](LICENSE), the project's license.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Full build, signing, and test steps: [docs/setup.md](docs/setup.md).
 | [docs/instant-upload.md](docs/instant-upload.md) | Instant iPhone → server uploads via a Shortcuts automation |
 | [notify/README.md](notify/README.md) | Notify sidecar setup and diagnostics |
 | [PRIVACY.md](PRIVACY.md) · [TERMS.md](TERMS.md) | Privacy policy and license terms |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute — setup, tests, and PR conventions |
+| [SECURITY.md](SECURITY.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Vulnerability reporting and community standards |
 
 Filing a bug? Include your iOS and VaultSync versions, your server's Syncthing version, whether Cloud Relay and `vaultsync-notify` are running, and relevant logs or screenshots.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+VaultSync syncs users' personal notes. Security reports are taken seriously and handled with priority — thank you for taking the time to report responsibly.
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+- **Preferred:** [GitHub Private Vulnerability Reporting](https://github.com/psimaker/vaultsync/security/advisories/new) — opens a private advisory visible only to you and the maintainer.
+- **Alternative:** email [umut.erdem@protonmail.com](mailto:umut.erdem@protonmail.com).
+
+Please include what you can: affected component and version, steps to reproduce, and your assessment of the impact. A proof of concept helps but is not required.
+
+## What to expect
+
+VaultSync is maintained by a single person. Honest expectations:
+
+- You will get an acknowledgment within a few days.
+- Confirmed vulnerabilities are fixed with priority and disclosed in coordination with you — details stay private until a fixed version has shipped.
+- You will be credited in the release notes if you wish.
+- There is no bug bounty program.
+
+## Supported versions
+
+Only the **latest release** of each component receives security fixes. If you are on an older version, please update first.
+
+| Component | Supported version |
+|---|---|
+| VaultSync iOS app | Latest App Store release (currently 1.8.2) |
+| `vaultsync-notify` server helper | Latest `notify-v*` release (currently 2.0.2) |
+| Cloud Relay (hosted service) | The currently deployed version (1.3.1) — operated by the maintainer, no user action needed |
+
+## Scope
+
+In scope:
+
+- The **iOS app** (`ios/`), including the embedded Go sync bridge (`go/bridge/`)
+- The **`vaultsync-notify` server helper** (`notify/`)
+- The **installer script** (`notify/scripts/install.sh`, served at `https://vaultsync.eu/notify.sh`)
+- **Release artifacts**: the Docker image and prebuilt helper binaries
+- The **Cloud Relay service** at `relay.vaultsync.eu` — the code lives in a separate repository, but the service is operated by the maintainer, so reports about its protocol or behavior are welcome here
+
+Strict limits for the hosted Relay:
+
+- **No testing against production infrastructure.** Report suspected issues from reading the [protocol reference](docs/relay-spec.md) or from traffic your own devices generate in normal use.
+- **No denial-of-service or load testing** of any kind.
+- **Never access, or attempt to access, data belonging to other users.**
+
+## Security design documentation
+
+The security-relevant design decisions — including threat models and the invariants that protect user data — are recorded in [`docs/decisions/`](docs/decisions/). The [Cloud Relay protocol reference](docs/relay-spec.md) documents the relay/helper/app trust boundaries.


### PR DESCRIPTION
## What

Adds the three standard community health files, all in English, at the repo root, and links them in the README documentation table:

- **SECURITY.md** — private vulnerability reporting via GitHub Private Vulnerability Reporting (primary) and email; a supported-versions table (app 1.8.2, `vaultsync-notify` 2.0.2, Cloud Relay 1.3.1 — latest release only); scope covering the app, helper, installer script, release artifacts, and the hosted relay with explicit limits (no testing against production, no DoS, no third-party data); honest solo-maintainer response expectations (acknowledgment within a few days, coordinated disclosure, no bounty); pointer to the threat models and decision records in `docs/decisions/`.
- **CONTRIBUTING.md** — a welcoming guide: which contributions help most (doctor-output bug reports, docs, NAS/Docker deployment experience, platform testing, translation review); issue-first for anything non-trivial, because wire contracts, the diagnostics protocol, and the data-safety invariants are frozen by binding decision records; honest dev setup (Go parts on Linux/macOS, iOS requires Xcode on macOS); Conventional Commit PR titles with the types `pr-title.yml` actually enforces; the four-language L10n key-parity rules; security findings go to SECURITY.md, not public issues.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, unmodified, with the same contact channel as SECURITY.md.

## Why

The repo's GitHub community health score was 57% — code of conduct and contributing guide missing, and no security policy. With 1000+ users and a public installer pipeline, a private, clearly scoped reporting channel matters; and the contributing guide lowers the barrier for the community help this project explicitly wants, while pointing newcomers at the decision records before they invest work in frozen areas.

Docs-only change: no code, tests, or CI behavior affected. All versions and CI facts were verified against `gh release list`, `CHANGELOG.md`, and the workflow files.

## Note for the maintainer

GitHub **Private Vulnerability Reporting must be enabled manually** in *Settings → Code security & analysis* for the SECURITY.md reporting link to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds standard community and security documentation at the repository root:

- `SECURITY.md` documents private vulnerability reporting, supported versions, scope, hosted Relay testing limits, response expectations, and security design references.
- `CONTRIBUTING.md` explains setup, contribution workflow, commit conventions, localization requirements, and security reporting.
- `CODE_OF_CONDUCT.md` adds the unmodified Contributor Covenant 2.1.
- `README.md` links to the new documents.

This is documentation-only; it does not change sync behavior, privacy controls, background execution, code, tests, or CI. GitHub Private Vulnerability Reporting must be enabled separately for its link to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->