### PR TITLE
docs(community): complete issue form set with triage fields and contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,13 @@
 name: Bug report
-description: Report a problem with VaultSync (iOS app, bridge, or relay)
+description: Report a problem with VaultSync (iOS app, bridge, server helper, or Cloud Relay)
 labels: [bug]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+        **Do not report security vulnerabilities here.** This is a public tracker — use the private channel described in [SECURITY.md](https://github.com/psimaker/vaultsync/blob/main/SECURITY.md) instead.
   - type: dropdown
     id: component
     attributes:
@@ -10,7 +16,8 @@ body:
         - iOS app
         - Widget
         - go bridge / Syncthing
-        - notify relay
+        - vaultsync-notify server helper
+        - Cloud Relay (hosted service)
         - Not sure
     validations:
       required: true
@@ -29,6 +36,37 @@ body:
       placeholder: "iOS 26.2, iPhone 15 Pro"
     validations:
       required: false
+  - type: input
+    id: server_syncthing_version
+    attributes:
+      label: Syncthing version on your server
+      description: "`syncthing --version` on the machine you sync with. Leave empty if no server is involved."
+      placeholder: "v2.0.1"
+    validations:
+      required: false
+  - type: dropdown
+    id: cloud_relay
+    attributes:
+      label: Is Cloud Relay active?
+      description: Settings → Cloud Relay in the app.
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: notify_helper
+    attributes:
+      label: Is vaultsync-notify running on your server?
+      description: If yes, please run the helper's self-check (`vaultsync-notify --doctor`) on the server and attach its output in the logs field below.
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+        - Not applicable — I don't use the server helper
+    validations:
+      required: true
   - type: textarea
     id: repro
     attributes:
@@ -40,6 +78,6 @@ body:
     id: logs
     attributes:
       label: Logs / screenshots
-      description: Optional — anything that helps narrow it down.
+      description: "Optional — anything that helps narrow it down (including `--doctor` output). **This is a public repository:** redact vault names, real file or folder paths, and device IDs before posting."
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/psimaker/vaultsync/security/advisories/new
+    about: Private disclosure — never open a public issue for security problems. See SECURITY.md for details.
+  - name: Troubleshooting guide
+    url: https://github.com/psimaker/vaultsync/blob/main/docs/troubleshooting.md
+    about: Common sync, pairing, and wake-up problems — worth a look before filing a bug.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest an improvement or new capability for VaultSync
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Describing the problem before the solution helps us find the best fit — sometimes a fix already exists.
+
+        Filing this issue already covers the "please open an issue first" step in [CONTRIBUTING.md](https://github.com/psimaker/vaultsync/blob/main/CONTRIBUTING.md). If you'd like to implement it yourself, say so below and we'll work out the design together.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what gets in the way today?
+      placeholder: "When I ..., I can't ... because ..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like it to work? Rough ideas are fine.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives & workarounds
+      description: What have you tried or considered instead?
+    validations:
+      required: false


### PR DESCRIPTION
## What

Completes the issue-template set under `.github/ISSUE_TEMPLATE/`: the existing bug form gets the triage fields the README already asks for, plus a new feature-request form and a template-chooser `config.yml`.

### bug_report.yml (revised, existing fields preserved)
- New fields matching the README's bug guidance: **Syncthing version on your server**, **Cloud Relay active?** (Yes/No/Not sure), **vaultsync-notify running?** — with a pointer to attach the helper's `--doctor` self-check output.
- **Privacy note** on the logs/screenshots field: public repo, redact vault names, real paths, and device IDs before posting.
- **Security notice** at the top: vulnerabilities go through the private channel in SECURITY.md, not the public tracker.
- Component dropdown: `notify relay` → **vaultsync-notify server helper**, plus a separate **Cloud Relay (hosted service)** option — the old name conflated the self-hosted helper with the hosted relay.

### feature_request.yml (new)
Problem/use case first, then optional solution and alternatives. Notes that filing the issue already satisfies the issue-first step in CONTRIBUTING.md. Label: `enhancement`.

### config.yml (new)
- `blank_issues_enabled: true` — questions stay welcome, nothing is blocked.
- Contact links: **Report a security vulnerability** → private advisory form, **Troubleshooting guide** → `docs/troubleshooting.md` (absolute URLs; Discussions are disabled, so no link points there).

## Why

Bug reports were arriving without the server-side context needed for triage (Syncthing version, relay/helper state), and the logs field invited pasting unredacted paths into a public repo. Feature ideas had no structured entry point.

## Verification

- All three files parse as YAML and were checked against GitHub's issue-forms schema (element types, attributes, validations, unique ids).
- Dropdown `Yes`/`No` options are quoted so they parse as strings, not YAML booleans.
- Only existing labels are referenced (`bug`, `enhancement`); `--doctor` verified in `notify/main.go`; all linked files (SECURITY.md, CONTRIBUTING.md, docs/troubleshooting.md) are tracked on `main`.

## Note

`gh api repos/psimaker/vaultsync/community/profile` may keep reporting `issue_template: false` — a known quirk of that endpoint with YAML issue forms. The forms themselves work when opening an issue; the metric is not worth chasing with dummy `.md` templates.