### PR TITLE
fix(conflicts): prevent Keep Both from replacing existing files (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to VaultSync are documented here.
 
 ### Fixed
 
+- **Keep Both no longer overwrites an existing conflict copy** ([#144](https://github.com/psimaker/vaultsync/issues/144)) — when the intended copy name is already occupied, VaultSync leaves all existing files untouched instead of replacing previously saved bytes.
 - **Manual conflict resolution preserves unrelated temporary files** ([#143](https://github.com/psimaker/vaultsync/issues/143)) — choosing the conflicting version no longer reuses or overwrites a pre-existing temporary file next to the note.
 
 ### Security

--- a/docs/decisions/027-keep-both-never-replaces-existing-files.md
+++ b/docs/decisions/027-keep-both-never-replaces-existing-files.md
@@ -1,0 +1,7 @@
+# 027 — Keep Both never replaces an existing file
+
+- Context: `KeepBothConflict` derived one destination name and could replace an existing regular file at that destination (#144), losing a previously preserved conflict copy.
+- Decision: Keep Both uses atomic no-replace semantics. Existing destination bytes are never replaced; a collision either produces an actually unique destination or returns an error, and success means every involved content remains present.
+- Why: “Keep Both” is a preservation promise. A crash or I/O failure between steps must prefer an extra copy over lost bytes, and cleanup never deletes user files automatically.
+- Rejected alternative: Checking with `Stat`/`fileExists` before a normal rename, because another operation can occupy the destination between check and rename; also rejected overwrite-then-repair, because overwritten bytes cannot be reconstructed safely.
+- Links: issue #144; `go/bridge/conflicts.go`, `go/bridge/conflicts_test.go`.

--- a/go/bridge/conflicts.go
+++ b/go/bridge/conflicts.go
@@ -15,8 +15,12 @@ import (
 	"strings"
 )
 
-// errPathTraversal is returned when a relative path attempts to escape the folder root.
-var errPathTraversal = errors.New("path traversal outside folder root")
+var (
+	// errPathTraversal is returned when a relative path attempts to escape the folder root.
+	errPathTraversal = errors.New("path traversal outside folder root")
+
+	errNoReplaceUnsupported = errors.New("atomic no-replace rename is not supported by this filesystem")
+)
 
 // ConflictFile describes a single conflict copy found in a folder.
 type ConflictFile struct {
@@ -33,6 +37,8 @@ var conflictPattern = regexp.MustCompile(`^(.+)\.sync-conflict-(\d{8}-\d{6})-([A
 // maxConflictScan limits the number of files examined during conflict detection
 // to prevent excessive I/O on very large vaults.
 const maxConflictScan = 10000
+
+const keepBothTargetExistsError = "keep both target already exists"
 
 // Syncthing's fs.IsTemporary recognizes the .syncthing. prefix, so the scanner
 // ignores these short-lived files instead of publishing them as vault content.
@@ -65,6 +71,18 @@ func systemConflictFileOperations() conflictFileOperations {
 		},
 		rename: os.Rename,
 		remove: os.Remove,
+	}
+}
+
+type keepBothFileOperations struct {
+	stat            func(string) (os.FileInfo, error)
+	renameNoReplace func(string, string) error
+}
+
+func systemKeepBothFileOperations() keepBothFileOperations {
+	return keepBothFileOperations{
+		stat:            os.Stat,
+		renameNoReplace: renameNoReplace,
 	}
 }
 
@@ -168,11 +186,21 @@ func KeepBothConflict(folderID, conflictFileName string) string {
 	if err != nil {
 		return "invalid path: outside folder root"
 	}
+	return keepBothConflictFile(conflictPath, conflictFileName, systemKeepBothFileOperations())
+}
 
-	if _, err := os.Stat(conflictPath); os.IsNotExist(err) {
+func keepBothConflictFile(conflictPath, conflictFileName string, ops keepBothFileOperations) string {
+	_, err := ops.stat(conflictPath)
+	if errors.Is(err, os.ErrNotExist) {
 		return "conflict file not found"
 	}
-
+	if err != nil {
+		var pathError *os.PathError
+		if errors.As(err, &pathError) {
+			err = pathError.Err
+		}
+		return fmt.Sprintf("inspect conflict file: %v", err)
+	}
 	name := filepath.Base(conflictFileName)
 	matches := conflictPattern.FindStringSubmatch(name)
 	if matches == nil {
@@ -183,8 +211,17 @@ func KeepBothConflict(folderID, conflictFileName string) string {
 	newName := matches[1] + ".conflict-" + matches[3] + matches[4]
 	newPath := filepath.Join(filepath.Dir(conflictPath), newName)
 
-	if err := os.Rename(conflictPath, newPath); err != nil {
-		return fmt.Sprintf("rename conflict file: %v", err)
+	if err := ops.renameNoReplace(conflictPath, newPath); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return keepBothTargetExistsError
+		}
+		if errors.Is(err, errNoReplaceUnsupported) {
+			return errNoReplaceUnsupported.Error()
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			return "conflict file not found"
+		}
+		return fmt.Sprintf("rename conflict file without replacing target: %v", err)
 	}
 
 	return ""

--- a/go/bridge/conflicts_test.go
+++ b/go/bridge/conflicts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -927,6 +928,509 @@ func TestKeepBothConflict(t *testing.T) {
 	}
 	if len(conflicts) != 0 {
 		t.Errorf("expected 0 conflicts after keep-both, got %d", len(conflicts))
+	}
+}
+
+func TestIssue144KeepBothPreservesExistingTarget(t *testing.T) {
+	configDir := testConfigDir(t)
+
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	const folderID = "issue144keepbothcollision"
+	folderPath := filepath.Join(configDir, folderID)
+	if errMsg := AddFolder(folderID, "Issue 144 Keep Both Collision", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+
+	conflictName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+	originalPath := filepath.Join(folderPath, "doc.md")
+	conflictPath := filepath.Join(folderPath, conflictName)
+	targetPath := filepath.Join(folderPath, "doc.conflict-DEF5678.md")
+	originalBytes := []byte("issue-144-original-sentinel")
+	conflictBytes := []byte("issue-144-conflict-sentinel")
+	targetBytes := []byte("issue-144-existing-target-sentinel")
+
+	if bytes.Equal(originalBytes, conflictBytes) || bytes.Equal(originalBytes, targetBytes) || bytes.Equal(conflictBytes, targetBytes) {
+		t.Fatal("issue #144 fixture bytes must be pairwise distinct")
+	}
+
+	fixtureFiles := []struct {
+		name string
+		path string
+		data []byte
+	}{
+		{name: "original", path: originalPath, data: originalBytes},
+		{name: "conflict", path: conflictPath, data: conflictBytes},
+		{name: "existing Keep Both target", path: targetPath, data: targetBytes},
+	}
+	for _, file := range fixtureFiles {
+		if err := os.WriteFile(file.path, file.data, 0o600); err != nil {
+			t.Fatalf("write %s fixture: %v", file.name, err)
+		}
+	}
+
+	before := make(map[string][]byte, len(fixtureFiles))
+	for _, file := range fixtureFiles {
+		got, err := os.ReadFile(file.path)
+		if err != nil {
+			t.Fatalf("read back %s fixture: %v", file.name, err)
+		}
+		if !bytes.Equal(got, file.data) {
+			t.Fatalf("%s fixture bytes = %q, want %q", file.name, got, file.data)
+		}
+		before[file.path] = append([]byte(nil), got...)
+	}
+
+	errMsg := KeepBothConflict(folderID, conflictName)
+
+	targetAfter, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read existing Keep Both target after KeepBothConflict: %v", err)
+	}
+	if !bytes.Equal(targetAfter, before[targetPath]) {
+		t.Errorf(
+			"existing Keep Both target bytes after KeepBothConflict(error=%q) = %q, want preserved bytes %q",
+			errMsg,
+			targetAfter,
+			before[targetPath],
+		)
+	}
+
+	originalAfter, err := os.ReadFile(originalPath)
+	if err != nil {
+		t.Fatalf("read original after KeepBothConflict: %v", err)
+	}
+	if !bytes.Equal(originalAfter, before[originalPath]) {
+		t.Errorf("original bytes after KeepBothConflict = %q, want %q", originalAfter, before[originalPath])
+	}
+
+	if errMsg != "" {
+		if errMsg != keepBothTargetExistsError {
+			t.Errorf("KeepBothConflict collision error = %q, want %q", errMsg, keepBothTargetExistsError)
+		}
+		conflictAfter, err := os.ReadFile(conflictPath)
+		if err != nil {
+			t.Fatalf("read conflict after non-destructive error %q: %v", errMsg, err)
+		}
+		if !bytes.Equal(conflictAfter, before[conflictPath]) {
+			t.Errorf("conflict bytes after error %q = %q, want %q", errMsg, conflictAfter, before[conflictPath])
+		}
+		return
+	}
+
+	if _, err := os.Stat(conflictPath); !os.IsNotExist(err) {
+		t.Errorf("successful KeepBothConflict left the sync-conflict source in place: %v", err)
+	}
+
+	entries, err := os.ReadDir(folderPath)
+	if err != nil {
+		t.Fatalf("read folder after KeepBothConflict: %v", err)
+	}
+	preservedConflictPath := ""
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		candidatePath := filepath.Join(folderPath, entry.Name())
+		candidateBytes, err := os.ReadFile(candidatePath)
+		if err != nil {
+			t.Fatalf("read %q while locating preserved conflict bytes: %v", entry.Name(), err)
+		}
+		if bytes.Equal(candidateBytes, before[conflictPath]) {
+			preservedConflictPath = candidatePath
+			break
+		}
+	}
+	if preservedConflictPath == "" {
+		t.Error("successful KeepBothConflict lost the conflict bytes")
+	} else if conflictPattern.MatchString(filepath.Base(preservedConflictPath)) {
+		t.Errorf("successful KeepBothConflict left conflict bytes under sync-conflict name %q", filepath.Base(preservedConflictPath))
+	}
+}
+
+func TestIssue144KeepBothSuccessPreservesAllContents(t *testing.T) {
+	dir := t.TempDir()
+	conflictName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+	originalPath := filepath.Join(dir, "doc.md")
+	conflictPath := filepath.Join(dir, conflictName)
+	targetPath := filepath.Join(dir, "doc.conflict-DEF5678.md")
+	unrelatedPath := filepath.Join(dir, "unrelated.md")
+	originalBytes := []byte("issue-144-success-original")
+	conflictBytes := []byte("issue-144-success-conflict")
+	unrelatedBytes := []byte("issue-144-success-unrelated")
+
+	issue144WriteAndReadBack(t, originalPath, originalBytes)
+	issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+	issue144WriteAndReadBack(t, unrelatedPath, unrelatedBytes)
+
+	if errMsg := keepBothConflictFile(conflictPath, conflictName, systemKeepBothFileOperations()); errMsg != "" {
+		t.Fatalf("keepBothConflictFile failed: %s", errMsg)
+	}
+
+	issue144AssertFileBytes(t, originalPath, originalBytes)
+	issue144AssertPathMissing(t, conflictPath)
+	issue144AssertFileBytes(t, targetPath, conflictBytes)
+	issue144AssertFileBytes(t, unrelatedPath, unrelatedBytes)
+}
+
+func TestIssue144KeepBothSameShortIDCollisionPreservesAllContents(t *testing.T) {
+	const folderID = "issue144sameid"
+	folderPath := issue144StartFolder(t, folderID)
+	originalPath := filepath.Join(folderPath, "doc.md")
+	firstName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+	secondName := "doc.sync-conflict-20260406-100001-DEF5678.md"
+	firstPath := filepath.Join(folderPath, firstName)
+	secondPath := filepath.Join(folderPath, secondName)
+	targetPath := filepath.Join(folderPath, "doc.conflict-DEF5678.md")
+	originalBytes := []byte("issue-144-same-id-original")
+	firstBytes := []byte("issue-144-same-id-first")
+	secondBytes := []byte("issue-144-same-id-second")
+
+	issue144WriteAndReadBack(t, originalPath, originalBytes)
+	issue144WriteAndReadBack(t, firstPath, firstBytes)
+	issue144WriteAndReadBack(t, secondPath, secondBytes)
+
+	if errMsg := KeepBothConflict(folderID, firstName); errMsg != "" {
+		t.Fatalf("first KeepBothConflict failed: %s", errMsg)
+	}
+	if errMsg := KeepBothConflict(folderID, secondName); errMsg != keepBothTargetExistsError {
+		t.Fatalf("second KeepBothConflict error = %q, want %q", errMsg, keepBothTargetExistsError)
+	}
+
+	issue144AssertFileBytes(t, originalPath, originalBytes)
+	issue144AssertPathMissing(t, firstPath)
+	issue144AssertFileBytes(t, targetPath, firstBytes)
+	issue144AssertFileBytes(t, secondPath, secondBytes)
+}
+
+func TestIssue144KeepBothParallelCollisionPreservesAllContents(t *testing.T) {
+	folderPath := t.TempDir()
+	originalPath := filepath.Join(folderPath, "doc.md")
+	unrelatedPath := filepath.Join(folderPath, "unrelated.md")
+	targetPath := filepath.Join(folderPath, "doc.conflict-DEF5678.md")
+	originalBytes := []byte("issue-144-parallel-original")
+	unrelatedBytes := []byte("issue-144-parallel-unrelated")
+
+	type parallelCandidate struct {
+		name string
+		path string
+		data []byte
+	}
+	candidates := []parallelCandidate{
+		{
+			name: "doc.sync-conflict-20260406-100000-DEF5678.md",
+			data: []byte("issue-144-parallel-first"),
+		},
+		{
+			name: "doc.sync-conflict-20260406-100001-DEF5678.md",
+			data: []byte("issue-144-parallel-second"),
+		},
+	}
+	for i := range candidates {
+		candidates[i].path = filepath.Join(folderPath, candidates[i].name)
+		issue144WriteAndReadBack(t, candidates[i].path, candidates[i].data)
+	}
+	issue144WriteAndReadBack(t, originalPath, originalBytes)
+	issue144WriteAndReadBack(t, unrelatedPath, unrelatedBytes)
+
+	type result struct {
+		candidate parallelCandidate
+		errMsg    string
+	}
+	start := make(chan struct{})
+	results := make(chan result, len(candidates))
+	var workers sync.WaitGroup
+	for _, candidate := range candidates {
+		workers.Add(1)
+		go func(candidate parallelCandidate) {
+			defer workers.Done()
+			<-start
+			results <- result{
+				candidate: candidate,
+				errMsg: keepBothConflictFile(
+					candidate.path,
+					candidate.name,
+					systemKeepBothFileOperations(),
+				),
+			}
+		}(candidate)
+	}
+	close(start)
+	workers.Wait()
+	close(results)
+
+	var winner, loser parallelCandidate
+	successes := 0
+	collisions := 0
+	for result := range results {
+		switch result.errMsg {
+		case "":
+			successes++
+			winner = result.candidate
+		case keepBothTargetExistsError:
+			collisions++
+			loser = result.candidate
+		default:
+			t.Errorf("parallel KeepBothConflict error = %q", result.errMsg)
+		}
+	}
+	if successes != 1 || collisions != 1 {
+		t.Fatalf("parallel results: successes=%d collisions=%d, want 1 each", successes, collisions)
+	}
+
+	issue144AssertFileBytes(t, originalPath, originalBytes)
+	issue144AssertFileBytes(t, unrelatedPath, unrelatedBytes)
+	issue144AssertFileBytes(t, targetPath, winner.data)
+	issue144AssertPathMissing(t, winner.path)
+	issue144AssertFileBytes(t, loser.path, loser.data)
+}
+
+func TestIssue144KeepBothRacingTargetCreationPreservesAllContents(t *testing.T) {
+	dir := t.TempDir()
+	conflictName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+	conflictPath := filepath.Join(dir, conflictName)
+	targetPath := filepath.Join(dir, "doc.conflict-DEF5678.md")
+	conflictBytes := []byte("issue-144-racing-source")
+	foreignBytes := []byte("issue-144-racing-foreign-target")
+	issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+
+	ops := systemKeepBothFileOperations()
+	nativeRenameNoReplace := ops.renameNoReplace
+	ops.renameNoReplace = func(oldPath, newPath string) error {
+		if oldPath != conflictPath || newPath != targetPath {
+			t.Errorf("rename paths = (%q, %q), want (%q, %q)", oldPath, newPath, conflictPath, targetPath)
+		}
+		file, err := os.OpenFile(newPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err != nil {
+			t.Fatalf("create racing target: %v", err)
+		}
+		if _, err := file.Write(foreignBytes); err != nil {
+			_ = file.Close()
+			t.Fatalf("write racing target: %v", err)
+		}
+		if err := file.Sync(); err != nil {
+			_ = file.Close()
+			t.Fatalf("sync racing target: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("close racing target: %v", err)
+		}
+		return nativeRenameNoReplace(oldPath, newPath)
+	}
+
+	if errMsg := keepBothConflictFile(conflictPath, conflictName, ops); errMsg != keepBothTargetExistsError {
+		t.Fatalf("racing Keep Both error = %q, want %q", errMsg, keepBothTargetExistsError)
+	}
+	issue144AssertFileBytes(t, conflictPath, conflictBytes)
+	issue144AssertFileBytes(t, targetPath, foreignBytes)
+}
+
+func TestIssue144KeepBothOperationFailuresPreserveAllContents(t *testing.T) {
+	t.Run("inspection I/O error", func(t *testing.T) {
+		dir := t.TempDir()
+		conflictName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+		conflictPath := filepath.Join(dir, conflictName)
+		targetPath := filepath.Join(dir, "doc.conflict-DEF5678.md")
+		conflictBytes := []byte("issue-144-inspection-io-source")
+		issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+
+		renameCalled := false
+		ops := keepBothFileOperations{
+			stat: func(string) (os.FileInfo, error) {
+				return nil, &os.PathError{Op: "stat", Path: conflictPath, Err: syscall.EIO}
+			},
+			renameNoReplace: func(string, string) error {
+				renameCalled = true
+				return nil
+			},
+		}
+		errMsg := keepBothConflictFile(conflictPath, conflictName, ops)
+		if !strings.HasPrefix(errMsg, "inspect conflict file: ") || !strings.Contains(errMsg, syscall.EIO.Error()) {
+			t.Errorf("inspection error = %q, want path-free EIO", errMsg)
+		}
+		if strings.Contains(errMsg, conflictPath) {
+			t.Errorf("inspection error leaked conflict path: %q", errMsg)
+		}
+		if renameCalled {
+			t.Error("rename was called after inspection failure")
+		}
+		issue144AssertFileBytes(t, conflictPath, conflictBytes)
+		issue144AssertPathMissing(t, targetPath)
+	})
+
+	operationErrors := []struct {
+		name          string
+		injectedError error
+		wantExact     string
+	}{
+		{name: "I/O error", injectedError: syscall.EIO},
+		{name: "ENOSPC", injectedError: syscall.ENOSPC},
+		{
+			name:          "unsupported filesystem",
+			injectedError: errNoReplaceUnsupported,
+			wantExact:     errNoReplaceUnsupported.Error(),
+		},
+	}
+	for _, testCase := range operationErrors {
+		t.Run(testCase.name, func(t *testing.T) {
+			dir := t.TempDir()
+			conflictName := "doc.sync-conflict-20260406-100000-DEF5678.md"
+			originalPath := filepath.Join(dir, "doc.md")
+			conflictPath := filepath.Join(dir, conflictName)
+			targetPath := filepath.Join(dir, "doc.conflict-DEF5678.md")
+			unrelatedPath := filepath.Join(dir, "unrelated.md")
+			originalBytes := []byte("issue-144-error-original")
+			conflictBytes := []byte("issue-144-error-conflict")
+			unrelatedBytes := []byte("issue-144-error-unrelated")
+			issue144WriteAndReadBack(t, originalPath, originalBytes)
+			issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+			issue144WriteAndReadBack(t, unrelatedPath, unrelatedBytes)
+
+			renameCalls := 0
+			ops := systemKeepBothFileOperations()
+			ops.renameNoReplace = func(oldPath, newPath string) error {
+				renameCalls++
+				if oldPath != conflictPath || newPath != targetPath {
+					t.Errorf("rename paths = (%q, %q), want (%q, %q)", oldPath, newPath, conflictPath, targetPath)
+				}
+				return testCase.injectedError
+			}
+			errMsg := keepBothConflictFile(conflictPath, conflictName, ops)
+			if testCase.wantExact != "" {
+				if errMsg != testCase.wantExact {
+					t.Errorf("mutation error = %q, want %q", errMsg, testCase.wantExact)
+				}
+			} else if !strings.HasPrefix(errMsg, "rename conflict file without replacing target: ") || !strings.Contains(errMsg, testCase.injectedError.Error()) {
+				t.Errorf("mutation error = %q, want stable prefix and %q", errMsg, testCase.injectedError.Error())
+			}
+			if renameCalls != 1 {
+				t.Errorf("rename calls = %d, want 1", renameCalls)
+			}
+			issue144AssertFileBytes(t, originalPath, originalBytes)
+			issue144AssertFileBytes(t, conflictPath, conflictBytes)
+			issue144AssertFileBytes(t, unrelatedPath, unrelatedBytes)
+			issue144AssertPathMissing(t, targetPath)
+		})
+	}
+}
+
+func TestIssue144KeepBothRejectsPathTraversal(t *testing.T) {
+	const folderID = "issue144traversal"
+	folderPath := issue144StartFolder(t, folderID)
+	outsideDir := filepath.Dir(folderPath)
+	outsideConflictName := "outside.sync-conflict-20260406-100000-DEF5678.md"
+	outsideConflictPath := filepath.Join(outsideDir, outsideConflictName)
+	outsideTargetPath := filepath.Join(outsideDir, "outside.conflict-DEF5678.md")
+	unrelatedPath := filepath.Join(outsideDir, "issue-144-traversal-unrelated.md")
+	conflictBytes := []byte("issue-144-traversal-conflict")
+	targetBytes := []byte("issue-144-traversal-target")
+	unrelatedBytes := []byte("issue-144-traversal-unrelated")
+	issue144WriteAndReadBack(t, outsideConflictPath, conflictBytes)
+	issue144WriteAndReadBack(t, outsideTargetPath, targetBytes)
+	issue144WriteAndReadBack(t, unrelatedPath, unrelatedBytes)
+
+	errMsg := KeepBothConflict(folderID, filepath.Join("..", outsideConflictName))
+	if errMsg != "invalid path: outside folder root" {
+		t.Fatalf("path traversal error = %q, want %q", errMsg, "invalid path: outside folder root")
+	}
+	issue144AssertFileBytes(t, outsideConflictPath, conflictBytes)
+	issue144AssertFileBytes(t, outsideTargetPath, targetBytes)
+	issue144AssertFileBytes(t, unrelatedPath, unrelatedBytes)
+}
+
+func TestIssue144KeepBothPreservesUnexpectedTargetNodes(t *testing.T) {
+	t.Run("directory", func(t *testing.T) {
+		dir := t.TempDir()
+		conflictName := "directory.sync-conflict-20260406-100000-DEF5678.md"
+		conflictPath := filepath.Join(dir, conflictName)
+		targetPath := filepath.Join(dir, "directory.conflict-DEF5678.md")
+		childPath := filepath.Join(targetPath, "sentinel.md")
+		conflictBytes := []byte("issue-144-target-directory-conflict")
+		childBytes := []byte("issue-144-target-directory-child")
+		issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+		if err := os.Mkdir(targetPath, 0o700); err != nil {
+			t.Fatalf("create target directory: %v", err)
+		}
+		issue144WriteAndReadBack(t, childPath, childBytes)
+
+		if errMsg := keepBothConflictFile(conflictPath, conflictName, systemKeepBothFileOperations()); errMsg != keepBothTargetExistsError {
+			t.Fatalf("directory target error = %q, want %q", errMsg, keepBothTargetExistsError)
+		}
+		issue144AssertFileBytes(t, conflictPath, conflictBytes)
+		issue144AssertFileBytes(t, childPath, childBytes)
+	})
+
+	t.Run("symlink", func(t *testing.T) {
+		dir := t.TempDir()
+		externalDir := t.TempDir()
+		conflictName := "symlink.sync-conflict-20260406-100000-DEF5678.md"
+		conflictPath := filepath.Join(dir, conflictName)
+		targetPath := filepath.Join(dir, "symlink.conflict-DEF5678.md")
+		externalPath := filepath.Join(externalDir, "external.md")
+		conflictBytes := []byte("issue-144-target-symlink-conflict")
+		externalBytes := []byte("issue-144-target-symlink-external")
+		issue144WriteAndReadBack(t, conflictPath, conflictBytes)
+		issue144WriteAndReadBack(t, externalPath, externalBytes)
+		if err := os.Symlink(externalPath, targetPath); err != nil {
+			t.Fatalf("create target symlink: %v", err)
+		}
+
+		if errMsg := keepBothConflictFile(conflictPath, conflictName, systemKeepBothFileOperations()); errMsg != keepBothTargetExistsError {
+			t.Fatalf("symlink target error = %q, want %q", errMsg, keepBothTargetExistsError)
+		}
+		issue144AssertFileBytes(t, conflictPath, conflictBytes)
+		linkTarget, err := os.Readlink(targetPath)
+		if err != nil {
+			t.Fatalf("read target symlink: %v", err)
+		}
+		if linkTarget != externalPath {
+			t.Errorf("target symlink destination = %q, want %q", linkTarget, externalPath)
+		}
+		issue144AssertFileBytes(t, externalPath, externalBytes)
+	})
+}
+
+func issue144StartFolder(t *testing.T, folderID string) string {
+	t.Helper()
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	t.Cleanup(func() { StopSyncthing() })
+
+	folderPath := filepath.Join(configDir, folderID)
+	if errMsg := AddFolder(folderID, "Issue 144 Keep Both", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+	return folderPath
+}
+
+func issue144WriteAndReadBack(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %q: %v", filepath.Base(path), err)
+	}
+	issue144AssertFileBytes(t, path, data)
+}
+
+func issue144AssertFileBytes(t *testing.T, path string, want []byte) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %q: %v", filepath.Base(path), err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("%q bytes = %q, want %q", filepath.Base(path), got, want)
+	}
+}
+
+func issue144AssertPathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Errorf("%q exists or lstat failed: %v", filepath.Base(path), err)
 	}
 }
 

--- a/go/bridge/rename_noreplace_apple.go
+++ b/go/bridge/rename_noreplace_apple.go
@@ -1,0 +1,17 @@
+//go:build darwin || ios
+
+package bridge
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameNoReplace(oldPath, newPath string) error {
+	err := unix.RenamexNp(oldPath, newPath, unix.RENAME_EXCL)
+	if errors.Is(err, unix.ENOTSUP) {
+		return errNoReplaceUnsupported
+	}
+	return err
+}

--- a/go/bridge/rename_noreplace_linux.go
+++ b/go/bridge/rename_noreplace_linux.go
@@ -1,0 +1,17 @@
+//go:build linux
+
+package bridge
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func renameNoReplace(oldPath, newPath string) error {
+	err := unix.Renameat2(unix.AT_FDCWD, oldPath, unix.AT_FDCWD, newPath, unix.RENAME_NOREPLACE)
+	if errors.Is(err, unix.ENOSYS) || errors.Is(err, unix.EINVAL) || errors.Is(err, unix.EOPNOTSUPP) {
+		return errNoReplaceUnsupported
+	}
+	return err
+}

--- a/go/bridge/rename_noreplace_unsupported.go
+++ b/go/bridge/rename_noreplace_unsupported.go
@@ -1,0 +1,7 @@
+//go:build !darwin && !ios && !linux
+
+package bridge
+
+func renameNoReplace(_, _ string) error {
+	return errNoReplaceUnsupported
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/syncthing/syncthing v1.30.0-rc.1.0.20260211104138-dc2a77ab8e5b
 	github.com/thejerf/suture/v4 v4.0.6
 	golang.org/x/mobile v0.0.0-20260312152759-81488f6aeb60
+	golang.org/x/sys v0.46.0
 )
 
 require (
@@ -68,7 +69,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.39.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.47.0 // indirect

--- a/ios/VaultSync/Models/SyncUserError.swift
+++ b/ios/VaultSync/Models/SyncUserError.swift
@@ -53,6 +53,26 @@ struct SyncUserError: Identifiable, Equatable, Sendable {
             return folderMarkerMissing(detail: rawMessage, path: nil)
         }
 
+        if normalized.contains("keep both target already exists") {
+            return SyncUserError(
+                category: .config,
+                title: L10n.tr("Conflict Resolution Failed"),
+                message: L10n.tr("Keep Both did not change any files because the new copy name is already in use."),
+                remediation: L10n.tr("Rename the existing copy in Files, then try Keep Both again."),
+                technicalDetails: rawMessage
+            )
+        }
+
+        if normalized.contains("atomic no-replace rename is not supported") {
+            return SyncUserError(
+                category: .fileAccess,
+                title: L10n.tr("Conflict Resolution Failed"),
+                message: L10n.tr("Keep Both did not change any files because this storage location does not support safe renaming."),
+                remediation: L10n.tr("Resolve this conflict manually in Files without replacing either file."),
+                technicalDetails: rawMessage
+            )
+        }
+
         if isRelayConnectivityError(normalized) {
             return SyncUserError(
                 category: .relayUnreachable,

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "Invalid Input" = "Ungültige Eingabe";
 "Invalid folder name: '%@'" = "Ungültiger Ordnername: „%@“";
 "Keep Both" = "Beide behalten";
+"Keep Both did not change any files because the new copy name is already in use." = "„Beide behalten“ hat keine Dateien geändert, weil der neue Kopiename bereits verwendet wird.";
+"Keep Both did not change any files because this storage location does not support safe renaming." = "„Beide behalten“ hat keine Dateien geändert, weil dieser Speicherort sicheres Umbenennen nicht unterstützt.";
 "Keep Other" = "Andere behalten";
 "Keep Other Device's Version" = "Version des anderen Geräts behalten";
 "Keep This" = "Diese behalten";
@@ -233,6 +235,8 @@
 "Remove and re-share the folder from your desktop device." = "Entferne den Ordner und teile ihn von deinem Desktop-Gerät erneut.";
 "Removed line. %@" = "Entfernte Zeile. %@";
 "Rename Failed" = "Umbenennen fehlgeschlagen";
+"Rename the existing copy in Files, then try Keep Both again." = "Benenne die vorhandene Kopie in der Dateien-App um und versuche dann erneut, beide zu behalten.";
+"Resolve this conflict manually in Files without replacing either file." = "Löse diesen Konflikt manuell in der Dateien-App, ohne eine der Dateien zu ersetzen.";
 "Renews" = "Verlängert sich";
 "Requesting camera access…" = "Kamerazugriff wird angefordert…";
 "Rescan Failed" = "Erneuter Scan fehlgeschlagen";

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -113,7 +113,7 @@
 "Invalid Input" = "Ungültige Eingabe";
 "Invalid folder name: '%@'" = "Ungültiger Ordnername: „%@“";
 "Keep Both" = "Beide behalten";
-"Keep Both did not change any files because the new copy name is already in use." = "„Beide behalten“ hat keine Dateien geändert, weil der neue Kopiename bereits verwendet wird.";
+"Keep Both did not change any files because the new copy name is already in use." = "„Beide behalten“ hat keine Dateien geändert, weil der Name der neuen Kopie bereits verwendet wird.";
 "Keep Both did not change any files because this storage location does not support safe renaming." = "„Beide behalten“ hat keine Dateien geändert, weil dieser Speicherort sicheres Umbenennen nicht unterstützt.";
 "Keep Other" = "Andere behalten";
 "Keep Other Device's Version" = "Version des anderen Geräts behalten";
@@ -235,7 +235,7 @@
 "Remove and re-share the folder from your desktop device." = "Entferne den Ordner und teile ihn von deinem Desktop-Gerät erneut.";
 "Removed line. %@" = "Entfernte Zeile. %@";
 "Rename Failed" = "Umbenennen fehlgeschlagen";
-"Rename the existing copy in Files, then try Keep Both again." = "Benenne die vorhandene Kopie in der Dateien-App um und versuche dann erneut, beide zu behalten.";
+"Rename the existing copy in Files, then try Keep Both again." = "Benenne die vorhandene Kopie in der Dateien-App um und versuche dann erneut „Beide behalten“.";
 "Resolve this conflict manually in Files without replacing either file." = "Löse diesen Konflikt manuell in der Dateien-App, ohne eine der Dateien zu ersetzen.";
 "Renews" = "Verlängert sich";
 "Requesting camera access…" = "Kamerazugriff wird angefordert…";

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "Invalid Input" = "Invalid Input";
 "Invalid folder name: '%@'" = "Invalid folder name: '%@'";
 "Keep Both" = "Keep Both";
+"Keep Both did not change any files because the new copy name is already in use." = "Keep Both did not change any files because the new copy name is already in use.";
+"Keep Both did not change any files because this storage location does not support safe renaming." = "Keep Both did not change any files because this storage location does not support safe renaming.";
 "Keep Other" = "Keep Other";
 "Keep Other Device's Version" = "Keep Other Device's Version";
 "Keep This" = "Keep This";
@@ -233,6 +235,8 @@
 "Remove and re-share the folder from your desktop device." = "Remove and re-share the folder from your desktop device.";
 "Removed line. %@" = "Removed line. %@";
 "Rename Failed" = "Rename Failed";
+"Rename the existing copy in Files, then try Keep Both again." = "Rename the existing copy in Files, then try Keep Both again.";
+"Resolve this conflict manually in Files without replacing either file." = "Resolve this conflict manually in Files without replacing either file.";
 "Renews" = "Renews";
 "Requesting camera access…" = "Requesting camera access…";
 "Rescan Failed" = "Rescan Failed";

--- a/ios/VaultSync/es.lproj/Localizable.strings
+++ b/ios/VaultSync/es.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "Invalid Input" = "Entrada no válida";
 "Invalid folder name: '%@'" = "Nombre de carpeta no válido: «%@»";
 "Keep Both" = "Conservar ambas";
+"Keep Both did not change any files because the new copy name is already in use." = "Conservar ambas no cambió ningún archivo porque el nuevo nombre de la copia ya está en uso.";
+"Keep Both did not change any files because this storage location does not support safe renaming." = "Conservar ambas no cambió ningún archivo porque esta ubicación de almacenamiento no admite el cambio de nombre seguro.";
 "Keep Other" = "Conservar la otra";
 "Keep Other Device's Version" = "Conservar la versión del otro dispositivo";
 "Keep This" = "Conservar esta";
@@ -233,6 +235,8 @@
 "Remove and re-share the folder from your desktop device." = "Elimina y vuelve a compartir la carpeta desde tu equipo de escritorio.";
 "Removed line. %@" = "Línea eliminada. %@";
 "Rename Failed" = "No se pudo renombrar";
+"Rename the existing copy in Files, then try Keep Both again." = "Cambia el nombre de la copia existente en Archivos y vuelve a intentar conservar ambas.";
+"Resolve this conflict manually in Files without replacing either file." = "Resuelve este conflicto manualmente en Archivos sin reemplazar ninguno de los archivos.";
 "Renews" = "Se renueva";
 "Requesting camera access…" = "Solicitando acceso a la cámara…";
 "Rescan Failed" = "El reescaneo falló";

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -113,6 +113,8 @@
 "Invalid Input" = "输入无效";
 "Invalid folder name: '%@'" = "无效的文件夹名称：“%@”";
 "Keep Both" = "两者都保留";
+"Keep Both did not change any files because the new copy name is already in use." = "“两者都保留”未更改任何文件，因为新副本名称已被使用。";
+"Keep Both did not change any files because this storage location does not support safe renaming." = "“两者都保留”未更改任何文件，因为此存储位置不支持安全重命名。";
 "Keep Other" = "保留对方版本";
 "Keep Other Device's Version" = "保留另一台设备的版本";
 "Keep This" = "保留此版本";
@@ -233,6 +235,8 @@
 "Remove and re-share the folder from your desktop device." = "从桌面设备中移除该文件夹并重新共享。";
 "Removed line. %@" = "已删除行。%@";
 "Rename Failed" = "重命名失败";
+"Rename the existing copy in Files, then try Keep Both again." = "请在“文件”中重命名现有副本，然后再次尝试保留两者。";
+"Resolve this conflict manually in Files without replacing either file." = "请在“文件”中手动解决此冲突，不要替换任何文件。";
 "Renews" = "续订";
 "Requesting camera access…" = "正在请求相机权限…";
 "Rescan Failed" = "重新扫描失败";

--- a/ios/VaultSyncTests/SyncUserErrorTests.swift
+++ b/ios/VaultSyncTests/SyncUserErrorTests.swift
@@ -62,6 +62,33 @@ struct SyncUserErrorTests {
     }
 }
 
+@Suite("Keep Both collision error mapping (#144)")
+struct KeepBothCollisionErrorMappingTests {
+    @Test("Explains that a name collision leaves every file unchanged")
+    func mapsKeepBothTargetCollision() {
+        let raw = "keep both target already exists"
+        let error = SyncUserError.from(rawMessage: raw)
+
+        #expect(error.category == .config)
+        #expect(error.title == L10n.tr("Conflict Resolution Failed"))
+        #expect(error.message == L10n.tr("Keep Both did not change any files because the new copy name is already in use."))
+        #expect(error.remediation == L10n.tr("Rename the existing copy in Files, then try Keep Both again."))
+        #expect(error.technicalDetails == raw)
+    }
+
+    @Test("Explains when storage cannot perform a safe Keep Both rename")
+    func mapsUnsupportedNoReplaceStorage() {
+        let raw = "atomic no-replace rename is not supported by this filesystem"
+        let error = SyncUserError.from(rawMessage: raw)
+
+        #expect(error.category == .fileAccess)
+        #expect(error.title == L10n.tr("Conflict Resolution Failed"))
+        #expect(error.message == L10n.tr("Keep Both did not change any files because this storage location does not support safe renaming."))
+        #expect(error.remediation == L10n.tr("Resolve this conflict manually in Files without replacing either file."))
+        #expect(error.technicalDetails == raw)
+    }
+}
+
 @Suite("Marker-missing folder error mapping (#65)")
 struct FolderMarkerMissingMappingTests {
     /// Syncthing's literal engine text (lib/config/folderconfiguration.go) —


### PR DESCRIPTION
Keep Both previously used an ordinary rename for its deterministic target, so an existing preserved conflict copy could be replaced silently.

Use native atomic no-replace renames on Apple and Linux, fail closed on collisions or unsupported filesystems, and leave recovery manual. Add issue-numbered byte-preservation, race, error, traversal, localization, and UI error-mapping coverage.

What could go wrong and why this is safe: a racy existence check or unsupported fallback could still destroy target bytes. The implementation uses exclusive kernel rename primitives, never falls back to replacing rename, and performs no cleanup deletion on failure.

Closes #144

<!-- PR titles follow Conventional Commits (feat:, fix:, docs:, chore:, ci: …);
     PRs are squash-merged, so the title becomes the commit subject on main. -->

## What & why
<!-- One or two sentences: what changes and why. Link the issue if there is one. -->

## Component(s)
- [ ] go (bridge / Syncthing)
- [ ] ios (app / widget)
- [ ] notify (relay)
- [ ] docs / CI

## Testing
- [ ] `cd go && make patch && go test -tags noassets ./bridge`
- [ ] `cd notify && go test ./...`
- [ ] iOS build / `xcodebuild test`
- [ ] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents “Keep Both” from overwriting existing conflict copies.
- Uses atomic no-replace rename operations on Apple and Linux.
- Fails safely on collisions, unsupported filesystems, rename errors, and unexpected target nodes.
- Preserves all file contents and performs no automatic cleanup deletion.
- Blocks path traversal and keeps recovery manual.
- Adds localized iOS error guidance in English, German, Spanish, and Simplified Chinese.
- Adds coverage for collisions, races, failures, traversal, node types, byte preservation, and error mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->