### PR TITLE
fix(conflicts): disable automatic .obsidian LWW mutation (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to VaultSync are documented here.
 
 ### Fixed
 
+- **Conflicting Obsidian settings now wait for your decision** ([#145](https://github.com/psimaker/vaultsync/issues/145)) — VaultSync no longer automatically deletes, replaces, or promotes `.obsidian` conflict copies by modification time. The legacy preference stays stored but cannot re-enable the retired behavior, and detected conflicts remain visible for manual review. Syncthing's separate conflict-copy retention is not guaranteed.
 - **Keep Both no longer overwrites an existing conflict copy** ([#144](https://github.com/psimaker/vaultsync/issues/144)) — when the intended copy name is already occupied, VaultSync leaves all existing files untouched instead of replacing previously saved bytes.
 - **Manual conflict resolution preserves unrelated temporary files** ([#143](https://github.com/psimaker/vaultsync/issues/143)) — choosing the conflicting version no longer reuses or overwrites a pre-existing temporary file next to the note.
 

--- a/docs/decisions/028-conflicts-require-manual-choice.md
+++ b/docs/decisions/028-conflicts-require-manual-choice.md
@@ -1,0 +1,9 @@
+# 028 — `.obsidian` conflicts require a manual choice
+
+- Context: VaultSync automatically applied last-writer-wins to `.obsidian` conflicts, allowing a background or foreground pass to delete or replace user bytes without a contemporaneous decision (#145).
+- Decision: No VaultSync-owned automatic path deletes, replaces, renames, or promotes a `.obsidian` original or conflict copy. These settings and plugin-state conflicts wait for manual review.
+- Compatibility: The legacy preference remains stored but is ignored, and the exported `AutoResolveStateConflicts` bridge entry point remains as a non-mutating compatibility no-op.
+- Why: Modification time cannot establish user intent, especially with clock skew, and a silent choice can propagate an unwanted result to every peer.
+- Rejected alternative: Keep opt-out last-writer-wins, because a missing or persisted `true` value would continue authorizing mutation without a decision at the time of conflict.
+- Boundary: Manual conflict actions remain available after explicit confirmation; Syncthing's separate conflict-copy retention is unchanged and not guaranteed indefinitely.
+- Links: issue [#145](https://github.com/psimaker/vaultsync/issues/145); `go/bridge/conflicts.go`; `ios/VaultSync/Services/SyncthingManager.swift`; `ios/VaultSync/Services/BackgroundSyncService.swift`.

--- a/docs/sync-filters-ux.md
+++ b/docs/sync-filters-ux.md
@@ -1,8 +1,8 @@
 # Sync Filters — UX Spec
 
 > **Internal design reference — not user documentation.** This captures the rationale, layout, and trade-offs behind the Sync Filters feature for maintainers extending it.
-> Status: **implemented** (issue [#1](https://github.com/psimaker/vaultsync/issues/1), shipped in v1.2.0; Conflict→Skip extended to Skip Family in v1.3.2, issue [#8](https://github.com/psimaker/vaultsync/issues/8); conflict auto-resolution for `.obsidian` state files added in v1.7.0, §6.6; multi-line paste + order-preserving filter writes in v1.7.1, issue [#43](https://github.com/psimaker/vaultsync/issues/43), §6.7). Current app: v1.7.1.
-> Last updated: 2026-06-13
+> Status: **implemented** (issue [#1](https://github.com/psimaker/vaultsync/issues/1), shipped in v1.2.0; Conflict→Skip extended to Skip Family in v1.3.2, issue [#8](https://github.com/psimaker/vaultsync/issues/8); automatic `.obsidian` conflict resolution added in v1.7.0 and retired under issue [#145](https://github.com/psimaker/vaultsync/issues/145), §6.6; multi-line paste + order-preserving filter writes in v1.7.1, issue [#43](https://github.com/psimaker/vaultsync/issues/43), §6.7). Current shipped app: v2.0.1.
+> Last updated: 2026-08-16
 
 This document is the design reference for the Sync Filters feature — the UI for excluding files and folders from sync requested in issue #1 by @vitaly74. It captures the rationale behind the layout, preset catalog, migration path, and multi-vault behavior; refer to it when extending or modifying the feature.
 
@@ -148,33 +148,34 @@ In typical Obsidian use, the sync folder is the **Obsidian root** and individual
 
 The vault scanner specifically descends one level into non-hidden subdirectories so that heavy folders inside vaults (e.g. `Obsidian/Personal/.git`, `Obsidian/Work/.git`) are detected and their sizes aggregated into a single "Found in this vault" entry per pattern.
 
-## 6.6 Conflict auto-resolution (v1.7.0)
+## 6.6 Manual conflict review
 
-Presets prevent the *predictable* conflict sources, but `.obsidian` holds many
-more files that churn on every device (`app.json`, `graph.json`, per-plugin
-`data.json`, …) — and ignoring all of them by default would also stop plugin
-*settings* from syncing, which users do want. So v1.7.0 attacks the noise from
-the other side:
+Presets prevent predictable conflict sources, but `.obsidian` also contains
+settings and plugin state that users expect to sync. VaultSync therefore keeps
+these files in the same explicit conflict workflow as notes instead of choosing
+a winner automatically:
 
-- **Auto-resolve, not ignore.** Conflict copies of any file inside a
-  `.obsidian` directory (any depth — covers vault-subdir layouts) are resolved
-  automatically with last-writer-wins: the newer mtime becomes the original,
-  the loser is deleted. A copy whose original vanished is promoted instead of
-  deleted, so nothing is ever lost. Implemented in the Go bridge
-  (`AutoResolveStateConflicts`, `go/bridge/conflicts.go`); triggered from the
-  foreground 2s poll (gated on the conflict scan actually containing a state
-  conflict) and from the background-sync path *before* the conflict
-  notification fires.
-- **Notes are exempt by design.** Anything outside `.obsidian` keeps the full
-  manual flow (diff view, Keep This/Other/Both, Skip Family) — last-writer-wins
-  on user content would mean silent data loss.
-- **Opt-out, not opt-in.** Settings → Conflicts → "Auto-Resolve Settings
-  Conflicts" (`SyncthingManager.autoResolveStateConflictsKey`, missing key =
-  ON). Users who turn it off see state conflicts in the normal manual flow
-  again.
+- **No app-owned automatic mutation.** Foreground and background sync leave
+  originals and conflict copies unchanged, regardless of their modification
+  times or whether the original is missing. Detected conflicts inside and
+  outside `.obsidian` remain available in the manual conflict UI.
+- **Legacy state cannot opt back in.** The historical
+  `auto-resolve-state-conflicts-v1` preference remains stored so an update does
+  not delete or reset user preferences, but its value is ignored. A persisted
+  `true` cannot restore automatic last-writer-wins behavior.
+- **Bridge compatibility is non-mutating.** The exported
+  `AutoResolveStateConflicts` entry point remains as a gomobile compatibility
+  no-op and makes no filesystem changes. Foreground and background code do not
+  call it.
+- **Manual choices remain available.** Keep This, Keep Other, Keep Both, and
+  Skip Family still run only after the user's explicit decision.
 - **Counts mean files now.** The home banner, vault badges, and notifications
   count distinct conflicted files instead of conflict copies — with
   `MaxConflicts: 10` a single churn-prone file used to read as "10 conflicts".
+- **Retention is a separate Syncthing policy.** VaultSync shows conflict copies
+  that Syncthing leaves on disk, but does not guarantee that Syncthing retains
+  any copy indefinitely. This manual-review doctrine does not change
+  Syncthing's own retention or versioning behavior.
 
 ## 6.7 Multi-line paste & order-preserving writes (v1.7.1)
 

--- a/go/bridge/conflicts.go
+++ b/go/bridge/conflicts.go
@@ -465,37 +465,13 @@ func RemoveConflictFilesForOriginal(folderID, originalPath string) string {
 	return emit(result{Removed: removed})
 }
 
-// stateDirName marks the directory whose contents count as app state (not
-// user notes) for conflict auto-resolution.
-const stateDirName = ".obsidian"
-
-// isStateFilePath reports whether the folder-relative path points inside a
-// `.obsidian` directory at any depth — covers both the single-vault layout
-// (`.obsidian/...`) and the Obsidian-root layout (`MyVault/.obsidian/...`).
-func isStateFilePath(relPath string) bool {
-	dir := filepath.ToSlash(filepath.Dir(relPath))
-	for _, part := range strings.Split(dir, "/") {
-		if part == stateDirName {
-			return true
-		}
-	}
-	return false
-}
-
-// AutoResolveStateConflicts resolves conflict copies of app-state files
-// (anything inside a `.obsidian` directory) without user interaction, using
-// last-writer-wins: a conflict copy newer than its original replaces the
-// original, an older (or equally old) copy is discarded. A copy whose
-// original no longer exists is promoted to be the original so no data is
-// lost. Files outside `.obsidian` directories are never touched.
-//
-// Stops after scanning maxConflictScan files, like GetConflictFilesJSON.
+// AutoResolveStateConflicts is retained for gomobile ABI compatibility but no
+// longer mutates conflict files. Conflict copies that are still present remain
+// visible through the manual conflict APIs.
 //
 // Returns a JSON string of the form:
 //
 //	{"resolved": <int>, "error": "<msg or empty>"}
-//
-// On a mid-loop failure the envelope carries the partial count plus the error.
 func AutoResolveStateConflicts(folderID string) string {
 	type result struct {
 		Resolved int    `json:"resolved"`
@@ -513,77 +489,10 @@ func AutoResolveStateConflicts(folderID string) string {
 	if folders == nil {
 		return emit(result{Error: "syncthing not running"})
 	}
-	folder, exists := folders[folderID]
+	_, exists := folders[folderID]
 	if !exists {
 		return emit(result{Error: "folder not found"})
 	}
 
-	// Collect first, mutate after the walk: renaming/removing entries while
-	// WalkDir iterates the same directories has platform-dependent results.
-	type candidate struct {
-		conflictPath string // absolute
-		originalPath string // absolute
-	}
-	var candidates []candidate
-	scanned := 0
-	filepath.WalkDir(folder.Path, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil
-		}
-		scanned++
-		if scanned > maxConflictScan {
-			return filepath.SkipAll
-		}
-		name := d.Name()
-		if !strings.Contains(name, ".sync-conflict-") {
-			return nil
-		}
-		matches := conflictPattern.FindStringSubmatch(name)
-		if matches == nil {
-			return nil
-		}
-		relPath, relErr := filepath.Rel(folder.Path, path)
-		if relErr != nil || !isStateFilePath(relPath) {
-			return nil
-		}
-		originalName := matches[1] + matches[4]
-		candidates = append(candidates, candidate{
-			conflictPath: path,
-			originalPath: filepath.Join(filepath.Dir(path), originalName),
-		})
-		return nil
-	})
-
-	resolved := 0
-	for _, c := range candidates {
-		conflictInfo, err := os.Stat(c.conflictPath)
-		if err != nil {
-			// Copy vanished since the walk (resolved elsewhere) — nothing to do.
-			continue
-		}
-		var keepCopy bool
-		originalInfo, err := os.Stat(c.originalPath)
-		switch {
-		case os.IsNotExist(err):
-			// The conflict copy is the only surviving version — promote it.
-			keepCopy = true
-		case err != nil:
-			return emit(result{Resolved: resolved, Error: fmt.Sprintf("stat %s: %v", filepath.Base(c.originalPath), err)})
-		default:
-			keepCopy = conflictInfo.ModTime().After(originalInfo.ModTime())
-		}
-		if keepCopy {
-			// Atomic on POSIX: replaces the original in one step.
-			if err := os.Rename(c.conflictPath, c.originalPath); err != nil {
-				return emit(result{Resolved: resolved, Error: fmt.Sprintf("promote %s: %v", filepath.Base(c.conflictPath), err)})
-			}
-		} else {
-			if err := os.Remove(c.conflictPath); err != nil {
-				return emit(result{Resolved: resolved, Error: fmt.Sprintf("remove %s: %v", filepath.Base(c.conflictPath), err)})
-			}
-		}
-		resolved++
-	}
-
-	return emit(result{Resolved: resolved})
+	return emit(result{})
 }

--- a/go/bridge/conflicts_test.go
+++ b/go/bridge/conflicts_test.go
@@ -1653,28 +1653,7 @@ func TestRemoveConflictFilesForOriginalErrors(t *testing.T) {
 	}
 }
 
-func TestIsStateFilePath(t *testing.T) {
-	cases := []struct {
-		relPath string
-		want    bool
-	}{
-		{".obsidian/workspace.json", true},
-		{".obsidian/plugins/dataview/data.json", true},
-		{"MyVault/.obsidian/app.json", true},
-		{"MyVault/.obsidian/plugins/calendar/data.json", true},
-		{"notes.md", false},
-		{"Personal/diary.md", false},
-		{".obsidian.md", false},
-		{"docs/.obsidian-guide/readme.md", false},
-	}
-	for _, c := range cases {
-		if got := isStateFilePath(c.relPath); got != c.want {
-			t.Errorf("isStateFilePath(%q) = %v, want %v", c.relPath, got, c.want)
-		}
-	}
-}
-
-func TestAutoResolveStateConflicts(t *testing.T) {
+func TestIssue145AutoResolveStateConflictsPreservesLegacyScenarios(t *testing.T) {
 	configDir := testConfigDir(t)
 
 	if errMsg := StartSyncthing(configDir); errMsg != "" {
@@ -1682,116 +1661,380 @@ func TestAutoResolveStateConflicts(t *testing.T) {
 	}
 	defer StopSyncthing()
 
-	folderPath := filepath.Join(configDir, "autoresolve")
-	if errMsg := AddFolder("autoresolve", "Auto Resolve", folderPath); errMsg != "" {
+	const folderID = "issue145-legacy"
+	folderPath := filepath.Join(configDir, folderID)
+	if errMsg := AddFolder(folderID, "Issue 145 Legacy Scenarios", folderPath); errMsg != "" {
 		t.Fatalf("AddFolder failed: %s", errMsg)
 	}
 
-	mustWrite := func(rel, content string) string {
-		full := filepath.Join(folderPath, filepath.FromSlash(rel))
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatalf("mkdir for %s: %v", rel, err)
-		}
-		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", rel, err)
-		}
-		return full
-	}
-	setMtime := func(path string, offsetSeconds int) {
-		ts := time.Now().Add(time.Duration(offsetSeconds) * time.Second)
-		if err := os.Chtimes(path, ts, ts); err != nil {
-			t.Fatalf("chtimes %s: %v", path, err)
-		}
+	type scenario struct {
+		name            string
+		originalRelPath string
+		conflictRelPath string
+		conflictDate    string
+		deviceShortID   string
+		createOriginal  bool
+		originalBytes   []byte
+		conflictBytes   []byte
+		originalMtime   time.Time
+		conflictMtime   time.Time
 	}
 
-	// Case 1: original newer than copy -> copy discarded, original content kept.
-	origNewer := mustWrite(".obsidian/workspace.json", "original-newer")
-	copyOlder := mustWrite(".obsidian/workspace.sync-conflict-20260601-100000-AAA1111.json", "copy-older")
-	setMtime(origNewer, 0)
-	setMtime(copyOlder, -3600)
+	baseMtime := time.Date(2026, time.August, 16, 10, 0, 0, 0, time.UTC)
+	scenarios := []scenario{
+		{
+			name:            "older conflict",
+			originalRelPath: ".obsidian/older.json",
+			conflictRelPath: ".obsidian/older.sync-conflict-20260816-100000-OLD0001.json",
+			conflictDate:    "20260816-100000",
+			deviceShortID:   "OLD0001",
+			createOriginal:  true,
+			originalBytes:   []byte("issue-145-older-original\x00"),
+			conflictBytes:   []byte("issue-145-older-conflict\x00"),
+			originalMtime:   baseMtime.Add(2 * time.Hour),
+			conflictMtime:   baseMtime,
+		},
+		{
+			name:            "newer conflict",
+			originalRelPath: "MyVault/.obsidian/newer.json",
+			conflictRelPath: "MyVault/.obsidian/newer.sync-conflict-20260816-110000-NEW0001.json",
+			conflictDate:    "20260816-110000",
+			deviceShortID:   "NEW0001",
+			createOriginal:  true,
+			originalBytes:   []byte("issue-145-newer-original\x00"),
+			conflictBytes:   []byte("issue-145-newer-conflict\x00"),
+			originalMtime:   baseMtime,
+			conflictMtime:   baseMtime.Add(2 * time.Hour),
+		},
+		{
+			name:            "equal mtimes",
+			originalRelPath: ".obsidian/equal.json",
+			conflictRelPath: ".obsidian/equal.sync-conflict-20260816-120000-EQL0001.json",
+			conflictDate:    "20260816-120000",
+			deviceShortID:   "EQL0001",
+			createOriginal:  true,
+			originalBytes:   []byte("issue-145-equal-original\x00"),
+			conflictBytes:   []byte("issue-145-equal-conflict\x00"),
+			originalMtime:   baseMtime.Add(4 * time.Hour),
+			conflictMtime:   baseMtime.Add(4 * time.Hour),
+		},
+		{
+			name:            "future clock skew",
+			originalRelPath: "MyVault/.obsidian/clock-skew.json",
+			conflictRelPath: "MyVault/.obsidian/clock-skew.sync-conflict-20260816-130000-CLK0001.json",
+			conflictDate:    "20260816-130000",
+			deviceShortID:   "CLK0001",
+			createOriginal:  true,
+			originalBytes:   []byte("issue-145-clock-skew-original\x00"),
+			conflictBytes:   []byte("issue-145-clock-skew-conflict\x00"),
+			originalMtime:   baseMtime,
+			conflictMtime:   time.Date(2046, time.August, 16, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			name:            "missing original",
+			originalRelPath: ".obsidian/missing.json",
+			conflictRelPath: ".obsidian/missing.sync-conflict-20260816-140000-MIS0001.json",
+			conflictDate:    "20260816-140000",
+			deviceShortID:   "MIS0001",
+			createOriginal:  false,
+			conflictBytes:   []byte("issue-145-missing-conflict\x00"),
+			conflictMtime:   baseMtime.Add(6 * time.Hour),
+		},
+	}
 
-	// Case 2: copy newer than original -> copy promoted over original.
-	origOlder := mustWrite("MyVault/.obsidian/app.json", "original-older")
-	copyNewer := mustWrite("MyVault/.obsidian/app.sync-conflict-20260601-110000-BBB2222.json", "copy-newer")
-	setMtime(origOlder, -3600)
-	setMtime(copyNewer, 0)
+	originalsBefore := make(map[string][]byte)
+	conflictsBefore := make(map[string][]byte, len(scenarios))
+	expectedConflicts := make(map[string]ConflictFile, len(scenarios))
 
-	// Case 3: original missing -> copy promoted, no data loss.
-	orphanCopy := mustWrite("MyVault/.obsidian/plugins/calendar/data.sync-conflict-20260601-120000-CCC3333.json", "orphan")
-	_ = orphanCopy
+	writeAndReadFixture := func(label, path string, data []byte, mtime time.Time) []byte {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("create directory for %s: %v", label, err)
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", label, err)
+		}
+		if err := os.Chtimes(path, mtime, mtime); err != nil {
+			t.Fatalf("set %s mtime: %v", label, err)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read back %s: %v", label, err)
+		}
+		if !bytes.Equal(got, data) {
+			t.Fatalf("%s bytes = %q, want %q", label, got, data)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", label, err)
+		}
+		if !info.ModTime().Equal(mtime) {
+			t.Fatalf("%s mtime = %s, want %s", label, info.ModTime(), mtime)
+		}
+		return append([]byte(nil), got...)
+	}
 
-	// Case 4: note conflict outside .obsidian -> untouched.
-	noteOrig := mustWrite("MyVault/diary.md", "note-original")
-	noteCopy := mustWrite("MyVault/diary.sync-conflict-20260601-130000-DDD4444.md", "note-copy")
-	setMtime(noteOrig, -3600)
-	setMtime(noteCopy, 0)
+	for _, scenario := range scenarios {
+		originalRelPath := filepath.FromSlash(scenario.originalRelPath)
+		conflictRelPath := filepath.FromSlash(scenario.conflictRelPath)
+		originalPath := filepath.Join(folderPath, originalRelPath)
+		conflictPath := filepath.Join(folderPath, conflictRelPath)
+		if scenario.createOriginal {
+			if bytes.Equal(scenario.originalBytes, scenario.conflictBytes) {
+				t.Fatalf("%s fixture bytes must be distinct", scenario.name)
+			}
+			originalsBefore[originalPath] = writeAndReadFixture(
+				scenario.name+" original",
+				originalPath,
+				scenario.originalBytes,
+				scenario.originalMtime,
+			)
+		} else if _, err := os.Lstat(originalPath); !os.IsNotExist(err) {
+			t.Fatalf("%s original must be absent before resolver: %v", scenario.name, err)
+		}
+		conflictsBefore[conflictPath] = writeAndReadFixture(
+			scenario.name+" conflict",
+			conflictPath,
+			scenario.conflictBytes,
+			scenario.conflictMtime,
+		)
+		expectedConflicts[conflictRelPath] = ConflictFile{
+			OriginalPath:  originalRelPath,
+			ConflictPath:  conflictRelPath,
+			ConflictDate:  scenario.conflictDate,
+			DeviceShortID: scenario.deviceShortID,
+		}
+	}
 
-	got := AutoResolveStateConflicts("autoresolve")
-	var res struct {
+	decodeConflicts := func(stage string) ([]ConflictFile, string) {
+		t.Helper()
+		raw := GetConflictFilesJSON(folderID)
+		var conflicts []ConflictFile
+		if err := json.Unmarshal([]byte(raw), &conflicts); err != nil {
+			t.Fatalf("decode conflicts %s resolver: %v (raw: %s)", stage, err, raw)
+		}
+		return conflicts, raw
+	}
+	conflictSetMatches := func(conflicts []ConflictFile) bool {
+		if len(conflicts) != len(expectedConflicts) {
+			return false
+		}
+		seen := make(map[string]struct{}, len(conflicts))
+		for _, conflict := range conflicts {
+			expected, exists := expectedConflicts[conflict.ConflictPath]
+			if !exists || conflict != expected {
+				return false
+			}
+			seen[conflict.ConflictPath] = struct{}{}
+		}
+		return len(seen) == len(expectedConflicts)
+	}
+
+	visibleBefore, visibleBeforeJSON := decodeConflicts("before")
+	if !conflictSetMatches(visibleBefore) {
+		t.Fatalf("conflicts before resolver = %s, want exact fixture set %+v", visibleBeforeJSON, expectedConflicts)
+	}
+
+	type autoResolveResult struct {
 		Resolved int    `json:"resolved"`
 		Error    string `json:"error"`
 	}
-	if err := json.Unmarshal([]byte(got), &res); err != nil {
-		t.Fatalf("unmarshal %q: %v", got, err)
-	}
-	if res.Error != "" {
-		t.Fatalf("error = %q, want empty", res.Error)
-	}
-	if res.Resolved != 3 {
-		t.Errorf("resolved = %d, want 3", res.Resolved)
+	decodeResult := func(label, raw string) autoResolveResult {
+		t.Helper()
+		var result autoResolveResult
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			t.Fatalf("decode %s result: %v (raw: %s)", label, err, raw)
+		}
+		return result
 	}
 
-	readFile := func(rel string) string {
-		data, err := os.ReadFile(filepath.Join(folderPath, filepath.FromSlash(rel)))
+	resolverJSON := AutoResolveStateConflicts(folderID)
+	resolverResult := decodeResult("valid folder", resolverJSON)
+	if resolverResult != (autoResolveResult{}) {
+		t.Errorf("valid-folder result = %+v, want resolved 0 and no error (raw: %s)", resolverResult, resolverJSON)
+	}
+
+	assertFilePreserved := func(label, path string, want []byte) {
+		t.Helper()
+		got, err := os.ReadFile(path)
 		if err != nil {
-			t.Fatalf("read %s: %v", rel, err)
+			t.Errorf("read %s after resolver: %v", label, err)
+			return
 		}
-		return string(data)
-	}
-	mustBeGone := func(rel string) {
-		if _, err := os.Stat(filepath.Join(folderPath, filepath.FromSlash(rel))); !os.IsNotExist(err) {
-			t.Errorf("%s still exists, want removed", rel)
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s bytes after resolver = %q, want unchanged %q", label, got, want)
 		}
 	}
-
-	// Case 1: original kept, copy gone.
-	if c := readFile(".obsidian/workspace.json"); c != "original-newer" {
-		t.Errorf("workspace.json = %q, want 'original-newer'", c)
-	}
-	mustBeGone(".obsidian/workspace.sync-conflict-20260601-100000-AAA1111.json")
-
-	// Case 2: copy promoted, copy file gone.
-	if c := readFile("MyVault/.obsidian/app.json"); c != "copy-newer" {
-		t.Errorf("app.json = %q, want 'copy-newer'", c)
-	}
-	mustBeGone("MyVault/.obsidian/app.sync-conflict-20260601-110000-BBB2222.json")
-
-	// Case 3: orphan promoted to original.
-	if c := readFile("MyVault/.obsidian/plugins/calendar/data.json"); c != "orphan" {
-		t.Errorf("data.json = %q, want 'orphan'", c)
-	}
-	mustBeGone("MyVault/.obsidian/plugins/calendar/data.sync-conflict-20260601-120000-CCC3333.json")
-
-	// Case 4: note conflict untouched.
-	if c := readFile("MyVault/diary.md"); c != "note-original" {
-		t.Errorf("diary.md = %q, want 'note-original'", c)
-	}
-	if c := readFile("MyVault/diary.sync-conflict-20260601-130000-DDD4444.md"); c != "note-copy" {
-		t.Errorf("diary conflict copy = %q, want 'note-copy'", c)
+	for _, scenario := range scenarios {
+		originalPath := filepath.Join(folderPath, filepath.FromSlash(scenario.originalRelPath))
+		conflictPath := filepath.Join(folderPath, filepath.FromSlash(scenario.conflictRelPath))
+		if scenario.createOriginal {
+			assertFilePreserved(scenario.name+" original", originalPath, originalsBefore[originalPath])
+		} else if _, err := os.Lstat(originalPath); !os.IsNotExist(err) {
+			t.Errorf("%s original was created or cannot be inspected after resolver: %v", scenario.name, err)
+		}
+		assertFilePreserved(scenario.name+" conflict", conflictPath, conflictsBefore[conflictPath])
 	}
 
-	// Idempotent: a second run finds nothing to resolve.
-	got = AutoResolveStateConflicts("autoresolve")
-	if err := json.Unmarshal([]byte(got), &res); err != nil {
-		t.Fatalf("unmarshal second run %q: %v", got, err)
-	}
-	if res.Resolved != 0 || res.Error != "" {
-		t.Errorf("second run = %+v, want resolved 0 and no error", res)
+	visibleAfter, visibleAfterJSON := decodeConflicts("after")
+	if !conflictSetMatches(visibleAfter) {
+		t.Errorf("conflicts after resolver = %s, want unchanged fixture set %+v", visibleAfterJSON, expectedConflicts)
 	}
 
-	// Unknown folder -> error envelope.
-	got = AutoResolveStateConflicts("nonexistent")
-	if !strings.Contains(got, `"error":"folder not found"`) {
-		t.Errorf("unknown folder result = %q, want 'folder not found'", got)
+	unknownJSON := AutoResolveStateConflicts("nonexistent")
+	unknownResult := decodeResult("unknown folder", unknownJSON)
+	if unknownResult != (autoResolveResult{Error: "folder not found"}) {
+		t.Errorf("unknown-folder result = %+v, want folder-not-found envelope (raw: %s)", unknownResult, unknownJSON)
+	}
+
+	StopSyncthing()
+	stoppedJSON := AutoResolveStateConflicts(folderID)
+	stoppedResult := decodeResult("stopped engine", stoppedJSON)
+	if stoppedResult != (autoResolveResult{Error: "syncthing not running"}) {
+		t.Errorf("stopped-engine result = %+v, want not-running envelope (raw: %s)", stoppedResult, stoppedJSON)
+	}
+}
+
+func TestIssue145AutoResolveStateConflictsPreservesAllFiles(t *testing.T) {
+	const (
+		folderID           = "issue145-preserve"
+		stateDirectoryName = ".obsidian"
+		originalName       = "workspace.json"
+		conflictName       = "workspace.sync-conflict-20260816-120000-ABC1234.json"
+	)
+
+	configDir := testConfigDir(t)
+	if errMsg := StartSyncthing(configDir); errMsg != "" {
+		t.Fatalf("StartSyncthing() failed: %s", errMsg)
+	}
+	defer StopSyncthing()
+
+	folderPath := filepath.Join(configDir, folderID)
+	if errMsg := AddFolder(folderID, "Issue 145 Preserve", folderPath); errMsg != "" {
+		t.Fatalf("AddFolder failed: %s", errMsg)
+	}
+
+	if matches := conflictPattern.FindStringSubmatch(conflictName); matches == nil {
+		t.Fatalf("conflict fixture %q does not match Syncthing conflict pattern", conflictName)
+	}
+
+	stateDir := filepath.Join(folderPath, stateDirectoryName)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("create .obsidian fixture directory: %v", err)
+	}
+	originalPath := filepath.Join(stateDir, originalName)
+	conflictPath := filepath.Join(stateDir, conflictName)
+	originalBytes := []byte("{\"source\":\"original-newer\",\"payload\":\"original-bytes\\u0000\"}\n")
+	conflictBytes := []byte("{\"source\":\"conflict-older\",\"payload\":\"conflict-bytes\\u0000\"}\n")
+	if bytes.Equal(originalBytes, conflictBytes) {
+		t.Fatal("fixture contents must be distinct")
+	}
+	if err := os.WriteFile(originalPath, originalBytes, 0o644); err != nil {
+		t.Fatalf("write original fixture: %v", err)
+	}
+	if err := os.WriteFile(conflictPath, conflictBytes, 0o644); err != nil {
+		t.Fatalf("write conflict fixture: %v", err)
+	}
+
+	conflictMtime := time.Date(2026, time.August, 16, 10, 0, 0, 0, time.UTC)
+	originalMtime := conflictMtime.Add(2 * time.Hour)
+	if err := os.Chtimes(originalPath, originalMtime, originalMtime); err != nil {
+		t.Fatalf("set original mtime: %v", err)
+	}
+	if err := os.Chtimes(conflictPath, conflictMtime, conflictMtime); err != nil {
+		t.Fatalf("set conflict mtime: %v", err)
+	}
+
+	readFixture := func(label, path string, want []byte) []byte {
+		t.Helper()
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s fixture before resolver: %v", label, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("%s fixture before resolver = %q, want exact bytes %q", label, got, want)
+		}
+		return got
+	}
+	originalBefore := readFixture("original", originalPath, originalBytes)
+	conflictBefore := readFixture("conflict", conflictPath, conflictBytes)
+
+	originalInfo, err := os.Stat(originalPath)
+	if err != nil {
+		t.Fatalf("stat original fixture before resolver: %v", err)
+	}
+	conflictInfo, err := os.Stat(conflictPath)
+	if err != nil {
+		t.Fatalf("stat conflict fixture before resolver: %v", err)
+	}
+	if !originalInfo.ModTime().Equal(originalMtime) {
+		t.Fatalf("original mtime = %s, want exact fixture time %s", originalInfo.ModTime(), originalMtime)
+	}
+	if !conflictInfo.ModTime().Equal(conflictMtime) {
+		t.Fatalf("conflict mtime = %s, want exact fixture time %s", conflictInfo.ModTime(), conflictMtime)
+	}
+	if !originalInfo.ModTime().After(conflictInfo.ModTime()) {
+		t.Fatalf("original mtime %s must be newer than conflict mtime %s", originalInfo.ModTime(), conflictInfo.ModTime())
+	}
+
+	expectedConflict := ConflictFile{
+		OriginalPath:  filepath.Join(stateDirectoryName, originalName),
+		ConflictPath:  filepath.Join(stateDirectoryName, conflictName),
+		ConflictDate:  "20260816-120000",
+		DeviceShortID: "ABC1234",
+	}
+	decodeConflicts := func(stage string) ([]ConflictFile, string) {
+		t.Helper()
+		raw := GetConflictFilesJSON(folderID)
+		var conflicts []ConflictFile
+		if err := json.Unmarshal([]byte(raw), &conflicts); err != nil {
+			t.Fatalf("decode conflicts %s resolver: %v (raw: %s)", stage, err, raw)
+		}
+		return conflicts, raw
+	}
+	conflictsBefore, rawConflictsBefore := decodeConflicts("before")
+	if len(conflictsBefore) != 1 || conflictsBefore[0] != expectedConflict {
+		t.Fatalf("conflict scan before resolver = %s, want exactly %+v", rawConflictsBefore, expectedConflict)
+	}
+
+	resolverJSON := AutoResolveStateConflicts(folderID)
+	var resolverResult struct {
+		Resolved int    `json:"resolved"`
+		Error    string `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(resolverJSON), &resolverResult); err != nil {
+		t.Fatalf("decode AutoResolveStateConflicts result: %v (raw: %s)", err, resolverJSON)
+	}
+	if resolverResult.Error != "" {
+		t.Fatalf("AutoResolveStateConflicts returned error %q (raw: %s)", resolverResult.Error, resolverJSON)
+	}
+
+	assertPreserved := func(label, path string, want []byte) {
+		t.Helper()
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s path must still exist after AutoResolveStateConflicts: %v (resolver: %s)", label, err, resolverJSON)
+		}
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("read %s after AutoResolveStateConflicts: %v (resolver: %s)", label, err, resolverJSON)
+			return
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("%s bytes after AutoResolveStateConflicts = %q, want unchanged %q (resolver: %s)", label, got, want, resolverJSON)
+		}
+	}
+	assertPreserved("original", originalPath, originalBefore)
+	assertPreserved("conflict", conflictPath, conflictBefore)
+
+	conflictsAfter, rawConflictsAfter := decodeConflicts("after")
+	foundConflict := false
+	for _, conflict := range conflictsAfter {
+		if conflict == expectedConflict {
+			foundConflict = true
+			break
+		}
+	}
+	if !foundConflict {
+		t.Errorf("conflict scan after resolver = %s, want preserved manual conflict %+v (resolver: %s)", rawConflictsAfter, expectedConflict, resolverJSON)
 	}
 }

--- a/ios/VaultSync/Services/BackgroundSyncService.swift
+++ b/ios/VaultSync/Services/BackgroundSyncService.swift
@@ -1213,11 +1213,6 @@ enum BackgroundSyncService {
         let bannersEnabled = (UserDefaults.standard.object(forKey: conflictNotificationsEnabledKey) as? Bool) ?? true
         guard bannersEnabled else { return }
 
-        // Resolve `.obsidian` state-file conflicts (last-writer-wins) before
-        // counting, so a background sync never wakes the user for conflicts
-        // the app can settle on its own. Same opt-out as the foreground poll.
-        autoResolveStateConflictsIfEnabled()
-
         guard let count = currentConflictCount() else {
             // Unreadable conflict snapshot (transient bridge/decode failure) —
             // leave the banner and persisted baseline untouched rather than
@@ -1267,25 +1262,6 @@ enum BackgroundSyncService {
                 logger.info("Conflict notification \(action == .alert ? "posted" : "updated quietly") (\(count) conflicts)")
             } catch {
                 logger.error("Failed to send notification")
-            }
-        }
-    }
-
-    /// Best-effort last-writer-wins cleanup of `.obsidian` state-file
-    /// conflicts across all folders. Runs in the background path before the
-    /// conflict count, mirroring what the foreground 2s poll does, so the
-    /// notification only ever reflects conflicts that need the user.
-    private static func autoResolveStateConflictsIfEnabled() {
-        guard SyncthingManager.isAutoResolveStateConflictsEnabled else { return }
-        let json = SyncBridgeService.getFoldersJSON()
-        guard let data = json.data(using: .utf8),
-              let folders = try? JSONDecoder().decode([FolderStub].self, from: data) else {
-            return
-        }
-        for folder in folders {
-            let result = SyncBridgeService.autoResolveStateConflicts(folderID: folder.id)
-            if result.resolved > 0 {
-                _ = SyncBridgeService.rescanFolder(folderID: folder.id)
             }
         }
     }

--- a/ios/VaultSync/Services/SyncBridgeService.swift
+++ b/ios/VaultSync/Services/SyncBridgeService.swift
@@ -290,10 +290,10 @@ struct SyncBridgeService {
         return (decoded.removed, nil)
     }
 
-    /// Auto-resolve conflict copies of Obsidian state files (anything inside a
-    /// `.obsidian` directory) using last-writer-wins. Returns the number of
-    /// resolved copies; `error` is non-nil when the loop failed partway, with
-    /// `resolved` carrying the partial count.
+    /// Legacy gomobile compatibility entry point. Automatic state-conflict
+    /// mutation was retired in #145; the Go bridge now leaves every file
+    /// untouched and returns zero resolved copies. Keep this signature stable
+    /// until the generated bridge contract can be removed independently.
     static func autoResolveStateConflicts(folderID: String) -> (resolved: Int, error: String?) {
         let raw = BridgeAutoResolveStateConflicts(folderID)
         struct Payload: Decodable {

--- a/ios/VaultSync/Services/SyncthingManager.swift
+++ b/ios/VaultSync/Services/SyncthingManager.swift
@@ -195,15 +195,19 @@ final class SyncthingManager {
         ".obsidian/workspace-mobile.json",
     ]
 
-    /// Opt-out switch for automatic last-writer-wins resolution of conflicts
-    /// on `.obsidian` state files. A missing key reads as ON so existing
-    /// installs get the calmer behaviour without migration. Shared with
-    /// `BackgroundSyncService` (background sync resolves before notifying)
-    /// and `SettingsView` (the toggle).
+    /// Retired preference key from the former automatic last-writer-wins
+    /// resolver. Keep the key stable and leave existing values untouched so an
+    /// upgrade never rewrites user preferences as part of this safety change.
     nonisolated static let autoResolveStateConflictsKey = "auto-resolve-state-conflicts-v1"
 
-    nonisolated static var isAutoResolveStateConflictsEnabled: Bool {
-        (UserDefaults.standard.object(forKey: autoResolveStateConflictsKey) as? Bool) ?? true
+    /// Safety tombstone for the retired automatic resolver (#145). The injected
+    /// defaults are deliberately ignored: a missing value, `false`, and a
+    /// persisted legacy `true` all leave automatic mutation disabled without
+    /// deleting or resetting the stored value.
+    nonisolated static func isAutoResolveStateConflictsEnabled(
+        defaults _: UserDefaults = .standard
+    ) -> Bool {
+        false
     }
 
     private var hasAppliedStartupIgnores = false
@@ -311,14 +315,6 @@ final class SyncthingManager {
         let deviceShortID: String
 
         var id: String { conflictPath }
-
-        /// True when the conflicted file is Obsidian app state (lives inside a
-        /// `.obsidian` directory at any depth) rather than a user note. State
-        /// conflicts are eligible for automatic last-writer-wins resolution.
-        /// Mirrors the Go bridge's `isStateFilePath`.
-        var isStateConflict: Bool {
-            originalPath.split(separator: "/").dropLast().contains(".obsidian")
-        }
     }
 
     struct PendingFolderInfo: Codable, Identifiable, Hashable, Sendable {
@@ -496,17 +492,6 @@ final class SyncthingManager {
     /// decision.
     var unresolvedConflictCount: Int {
         conflictFiles.values.reduce(0) { $0 + Set($1.map(\.originalPath)).count }
-    }
-
-    /// Decode a conflict-scan payload and report whether any entry is an
-    /// auto-resolvable state conflict. Gates the auto-resolve walk in the
-    /// poll loop on folders that actually need it.
-    nonisolated static func containsStateConflict(conflictsJSON: String) -> Bool {
-        guard let data = conflictsJSON.data(using: .utf8),
-              let decoded = try? JSONDecoder().decode([ConflictInfo].self, from: data) else {
-            return false
-        }
-        return decoded.contains { $0.isStateConflict }
     }
 
     var unresolvedIssues: [SyncIssueItem] {
@@ -1225,25 +1210,11 @@ final class SyncthingManager {
         let statusSnapshot = await Task.detached {
             var statuses: [String: FolderStatusInfo] = [:]
             var conflicts: [String: Data] = [:]
-            let autoResolve = Self.isAutoResolveStateConflictsEnabled
             for folder in currentFolders {
                 if let status = SyncBridgeService.getFolderStatus(folderID: folder.id) {
                     statuses[folder.id] = FolderStatusInfo(payload: status)
                 }
-                var cJSON = SyncBridgeService.getConflictFilesJSON(folderID: folder.id)
-                // Gate the (extra) auto-resolve walk on the scan we already
-                // have, so the 2s poll only pays for it when a state conflict
-                // actually exists.
-                if autoResolve, Self.containsStateConflict(conflictsJSON: cJSON) {
-                    let result = SyncBridgeService.autoResolveStateConflicts(folderID: folder.id)
-                    if result.resolved > 0 {
-                        // Keep Syncthing's index in line with the on-disk
-                        // changes, then re-read so this poll already reports
-                        // the calmer state.
-                        _ = SyncBridgeService.rescanFolder(folderID: folder.id)
-                        cJSON = SyncBridgeService.getConflictFilesJSON(folderID: folder.id)
-                    }
-                }
+                let cJSON = SyncBridgeService.getConflictFilesJSON(folderID: folder.id)
                 if let d = cJSON.data(using: .utf8) {
                     conflicts[folder.id] = d
                 }

--- a/ios/VaultSync/Views/SettingsView.swift
+++ b/ios/VaultSync/Views/SettingsView.swift
@@ -16,7 +16,6 @@ struct SettingsView: View {
     @State private var showThankYou = false
     @State private var deviceIDCopied = false
     @AppStorage(BackgroundSyncService.conflictNotificationsEnabledKey) private var conflictNotificationsEnabled = true
-    @AppStorage(SyncthingManager.autoResolveStateConflictsKey) private var autoResolveStateConflicts = true
     @Environment(\.dismiss) private var dismiss
 
     // Cloud Relay now lives entirely in its own tab (RelayHomeView) — subscribe,
@@ -123,13 +122,11 @@ struct SettingsView: View {
 
     private var conflictsSection: some View {
         Section {
-            Toggle(isOn: $autoResolveStateConflicts) {
-                Label(L10n.tr("Auto-Resolve Settings Conflicts"), systemImage: "wand.and.stars")
-            }
+            Label(L10n.tr("Review Conflicts Manually"), systemImage: "exclamationmark.triangle")
         } header: {
             Text(L10n.tr("Conflicts"))
         } footer: {
-            Text(L10n.tr("Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision."))
+            Text(L10n.tr("VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep."))
         }
     }
 

--- a/ios/VaultSync/de.lproj/Localizable.strings
+++ b/ios/VaultSync/de.lproj/Localizable.strings
@@ -644,9 +644,9 @@
 "Low Power Mode is on — iOS defers silent wake-ups until it is off or the iPhone is charging." = "Der Stromsparmodus ist aktiv – iOS verzögert stille Weck-Signale, bis er ausgeschaltet ist oder das iPhone lädt.";
 "Keep VaultSync in the background: if you force-quit it from the app switcher, iOS stops delivering wake-ups until you open the app again." = "Lass VaultSync im Hintergrund: Wenn du die App im App-Umschalter wegwischst, stellt iOS keine Weck-Signale mehr zu, bis du die App wieder öffnest.";
 
-/* Conflict auto-resolution — .obsidian state files, last-writer-wins (Settings) */
-"Auto-Resolve Settings Conflicts" = "Einstellungs-Konflikte automatisch lösen";
-"Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision." = "Konflikte in Obsidians App-Einstellungen und Plugin-Daten (.obsidian) werden automatisch gelöst – die neueste Version gewinnt. Konflikte in deinen Notizen warten immer auf deine Entscheidung.";
+/* Manual conflict review — notes and .obsidian state (Settings) */
+"Review Conflicts Manually" = "Konflikte manuell prüfen";
+"VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep." = "VaultSync wählt nicht automatisch zwischen Konfliktkopien in deinen Notizen, Obsidian-Einstellungen oder Plugin-Daten. Prüfe jeden Konflikt und entscheide, was du behalten möchtest.";
 
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Zwei Vaults teilen sich einen Ordner";

--- a/ios/VaultSync/en.lproj/Localizable.strings
+++ b/ios/VaultSync/en.lproj/Localizable.strings
@@ -644,9 +644,9 @@
 "Low Power Mode is on — iOS defers silent wake-ups until it is off or the iPhone is charging." = "Low Power Mode is on — iOS defers silent wake-ups until it is off or the iPhone is charging.";
 "Keep VaultSync in the background: if you force-quit it from the app switcher, iOS stops delivering wake-ups until you open the app again." = "Keep VaultSync in the background: if you force-quit it from the app switcher, iOS stops delivering wake-ups until you open the app again.";
 
-/* Conflict auto-resolution — .obsidian state files, last-writer-wins (Settings) */
-"Auto-Resolve Settings Conflicts" = "Auto-Resolve Settings Conflicts";
-"Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision." = "Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision.";
+/* Manual conflict review — notes and .obsidian state (Settings) */
+"Review Conflicts Manually" = "Review Conflicts Manually";
+"VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep." = "VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep.";
 
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Two Vaults Are Sharing One Folder";

--- a/ios/VaultSync/es.lproj/Localizable.strings
+++ b/ios/VaultSync/es.lproj/Localizable.strings
@@ -644,9 +644,9 @@
 "Low Power Mode is on — iOS defers silent wake-ups until it is off or the iPhone is charging." = "El modo de bajo consumo está activado: iOS aplaza las señales de activación silenciosas hasta que se desactive o el iPhone se cargue.";
 "Keep VaultSync in the background: if you force-quit it from the app switcher, iOS stops delivering wake-ups until you open the app again." = "Mantén VaultSync en segundo plano: si la cierras desde el selector de aplicaciones, iOS dejará de entregar señales de activación hasta que vuelvas a abrir la app.";
 
-/* Conflict auto-resolution — .obsidian state files, last-writer-wins (Settings) */
-"Auto-Resolve Settings Conflicts" = "Resolver conflictos de ajustes automáticamente";
-"Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision." = "Los conflictos en los ajustes de la aplicación Obsidian y el estado de los plugins (.obsidian) se resuelven automáticamente: gana la versión más reciente. Los conflictos en tus notas siempre esperan tu decisión.";
+/* Manual conflict review — notes and .obsidian state (Settings) */
+"Review Conflicts Manually" = "Revisar conflictos manualmente";
+"VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep." = "VaultSync no elige automáticamente entre copias en conflicto de tus notas, los ajustes de Obsidian o el estado de los plugins. Revisa cada conflicto y decide qué conservar.";
 
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "Dos Vaults comparten una misma carpeta";

--- a/ios/VaultSync/zh-Hans.lproj/Localizable.strings
+++ b/ios/VaultSync/zh-Hans.lproj/Localizable.strings
@@ -644,9 +644,9 @@
 "Low Power Mode is on — iOS defers silent wake-ups until it is off or the iPhone is charging." = "低电量模式已开启——iOS 会推迟静默唤醒信号，直到关闭该模式或 iPhone 充电。";
 "Keep VaultSync in the background: if you force-quit it from the app switcher, iOS stops delivering wake-ups until you open the app again." = "请让 VaultSync 保留在后台：如果在应用切换器中强制退出，iOS 将停止递送唤醒信号，直到你再次打开应用。";
 
-/* Conflict auto-resolution — .obsidian state files, last-writer-wins (Settings) */
-"Auto-Resolve Settings Conflicts" = "自动解决设置冲突";
-"Conflicts in Obsidian's app settings and plugin state (.obsidian) are resolved automatically — the newest version wins. Conflicts in your notes always wait for your decision." = "Obsidian 应用设置和插件状态（.obsidian）中的冲突会自动解决——保留最新版本。笔记中的冲突始终等待你的决定。";
+/* Manual conflict review — notes and .obsidian state (Settings) */
+"Review Conflicts Manually" = "手动检查冲突";
+"VaultSync does not automatically choose between conflicting copies in your notes, Obsidian settings, or plugin state. Review each conflict and decide what to keep." = "VaultSync 不会自动在笔记、Obsidian 设置或插件状态的冲突副本之间做出选择。请逐一检查冲突，并决定要保留的内容。";
 
 /* Path collision migration shield (#45) — vaults an older version already merged onto one folder */
 "Two Vaults Are Sharing One Folder" = "两个 Vault 共用同一个文件夹";

--- a/ios/VaultSyncTests/ConflictAutoResolveTests.swift
+++ b/ios/VaultSyncTests/ConflictAutoResolveTests.swift
@@ -2,12 +2,9 @@ import Foundation
 import Testing
 @testable import VaultSync
 
-/// Pins the Swift-side classification and counting that powers conflict
-/// auto-resolution: which conflicts count as auto-resolvable `.obsidian`
-/// state, and how the home-screen banner counts distinct files instead of
-/// conflict copies. The on-disk resolution itself lives in the Go bridge
-/// (AutoResolveStateConflicts) and is tested there.
-@Suite("Conflict auto-resolve classification")
+/// Pins the retired automatic resolver's safety policy and keeps the conflict
+/// count semantics independent of the number of copies for one file (#145).
+@Suite("Automatic conflict mutation disabled (#145)")
 struct ConflictAutoResolveTests {
 
     private func conflict(
@@ -22,42 +19,74 @@ struct ConflictAutoResolveTests {
         )
     }
 
-    // MARK: - isStateConflict
+    // MARK: - Retired preference policy
 
-    @Test("Files inside .obsidian are state conflicts at any depth")
-    func obsidianFilesAreState() {
-        #expect(conflict(".obsidian/workspace.json").isStateConflict)
-        #expect(conflict(".obsidian/plugins/dataview/data.json").isStateConflict)
-        #expect(conflict("MyVault/.obsidian/app.json").isStateConflict)
-        #expect(conflict("MyVault/.obsidian/plugins/calendar/data.json").isStateConflict)
+    @Test("Missing legacy preference cannot enable automatic mutation (#145)")
+    func issue145MissingLegacyPreferenceStaysDisabledAndAbsent() {
+        let defaults = TestSupport.makeIsolatedDefaults(label: "issue-145-missing")
+        let key = SyncthingManager.autoResolveStateConflictsKey
+
+        #expect(defaults.object(forKey: key) == nil)
+        #expect(!SyncthingManager.isAutoResolveStateConflictsEnabled(defaults: defaults))
+        #expect(defaults.object(forKey: key) == nil)
     }
 
-    @Test("Notes and lookalike paths are not state conflicts")
-    func notesAreNotState() {
-        #expect(!conflict("notes.md").isStateConflict)
-        #expect(!conflict("Personal/diary.md").isStateConflict)
-        // A file literally named ".obsidian.md" is a note, not state.
-        #expect(!conflict(".obsidian.md").isStateConflict)
-        // Only the exact directory name counts, not a prefix of it.
-        #expect(!conflict("docs/.obsidian-guide/readme.md").isStateConflict)
+    @Test("Legacy false preference stays disabled and intact (#145)")
+    func issue145LegacyFalseStaysDisabledAndIntact() {
+        let defaults = TestSupport.makeIsolatedDefaults(label: "issue-145-false")
+        let key = SyncthingManager.autoResolveStateConflictsKey
+        defaults.set(false, forKey: key)
+
+        #expect(!SyncthingManager.isAutoResolveStateConflictsEnabled(defaults: defaults))
+        #expect((defaults.object(forKey: key) as? Bool) == false)
     }
 
-    // MARK: - containsStateConflict (poll-loop gate)
+    @Test("Legacy true preference cannot re-enable mutation and stays intact (#145)")
+    func issue145LegacyTrueStaysDisabledAndIntact() {
+        let defaults = TestSupport.makeIsolatedDefaults(label: "issue-145-true")
+        let key = SyncthingManager.autoResolveStateConflictsKey
+        defaults.set(true, forKey: key)
 
-    @Test("JSON gate detects a state conflict among notes")
-    func gateDetectsStateConflict() throws {
-        let mixed = [conflict("a.md"), conflict("V/.obsidian/app.json")]
-        let json = String(data: try JSONEncoder().encode(mixed), encoding: .utf8)!
-        #expect(SyncthingManager.containsStateConflict(conflictsJSON: json))
+        #expect(!SyncthingManager.isAutoResolveStateConflictsEnabled(defaults: defaults))
+        #expect((defaults.object(forKey: key) as? Bool) == true)
     }
 
-    @Test("JSON gate stays quiet for notes-only and invalid payloads")
-    func gateQuietOtherwise() throws {
-        let notes = [conflict("a.md"), conflict("V/b.md")]
-        let json = String(data: try JSONEncoder().encode(notes), encoding: .utf8)!
-        #expect(!SyncthingManager.containsStateConflict(conflictsJSON: json))
-        #expect(!SyncthingManager.containsStateConflict(conflictsJSON: "[]"))
-        #expect(!SyncthingManager.containsStateConflict(conflictsJSON: "not json"))
+    // MARK: - Automatic caller removal
+
+    @Test("Foreground poll has no automatic resolver call (#145)")
+    func issue145ForegroundSourceHasNoAutomaticResolverCall() throws {
+        let source = try productSource("VaultSync/Services/SyncthingManager.swift")
+        expectNoAutomaticResolverCall(in: source)
+    }
+
+    @Test("Background paths have no automatic resolver call (#145)")
+    func issue145BackgroundSourceHasNoAutomaticResolverCall() throws {
+        let source = try productSource("VaultSync/Services/BackgroundSyncService.swift")
+        expectNoAutomaticResolverCall(in: source)
+    }
+
+    @Test("No product source can route around the retired callers (#145)")
+    func issue145ProductSourcesHaveNoAutomaticResolverReference() throws {
+        let productDirectory = productURL("VaultSync")
+        guard let enumerator = FileManager.default.enumerator(
+            at: productDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            Issue.record("Could not enumerate VaultSync product sources")
+            return
+        }
+
+        var auditedSourceCount = 0
+        for case let sourceURL as URL in enumerator {
+            guard sourceURL.pathExtension == "swift",
+                  sourceURL.lastPathComponent != "SyncBridgeService.swift" else {
+                continue
+            }
+            auditedSourceCount += 1
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            expectNoAutomaticResolverCall(in: source)
+        }
+        #expect(auditedSourceCount > 0)
     }
 
     // MARK: - Distinct-file conflict count
@@ -87,5 +116,22 @@ struct ConflictAutoResolveTests {
         let manager = SyncthingManager()
         manager._testSetConflictFiles([:])
         #expect(manager.unresolvedConflictCount == 0)
+    }
+
+    private func productSource(_ relativePath: String, filePath: StaticString = #filePath) throws -> String {
+        try String(contentsOf: productURL(relativePath, filePath: filePath), encoding: .utf8)
+    }
+
+    private func productURL(_ relativePath: String, filePath: StaticString = #filePath) -> URL {
+        let iosDirectory = URL(fileURLWithPath: "\(filePath)")
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return iosDirectory.appendingPathComponent(relativePath)
+    }
+
+    private func expectNoAutomaticResolverCall(in source: String) {
+        let compact = source.filter { !$0.isWhitespace }
+        #expect(!compact.contains("SyncBridgeService.autoResolveStateConflicts"))
+        #expect(!compact.contains("BridgeAutoResolveStateConflicts"))
     }
 }


### PR DESCRIPTION
Foreground and background sync previously invoked a timestamp-based resolver that could delete, replace, or promote .obsidian conflict copies without a contemporaneous user decision.

Remove both automatic call paths, preserve but ignore the legacy preference, retain the gomobile entry point as a non-mutating compatibility no-op, and keep conflicts in the manual review flow.

What could go wrong and why this is safe: an overlooked caller or stale bridge binary could still mutate user bytes. The Go export itself now performs no filesystem operation, issue-numbered tests preserve exact bytes across Mtime, clock-skew, and missing-original cases, the XCFramework was rebuilt, and the complete Go and Xcode suites pass.

Closes #145

<!-- PR titles follow Conventional Commits (feat:, fix:, docs:, chore:, ci: …);
     PRs are squash-merged, so the title becomes the commit subject on main. -->

## What & why
<!-- One or two sentences: what changes and why. Link the issue if there is one. -->

## Component(s)
- [ ] go (bridge / Syncthing)
- [ ] ios (app / widget)
- [ ] notify (relay)
- [ ] docs / CI

## Testing
- [ ] `cd go && make patch && go test -tags noassets ./bridge`
- [ ] `cd notify && go test ./...`
- [ ] iOS build / `xcodebuild test`
- [ ] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Disabled automatic `.obsidian` conflict resolution in foreground and background sync.
- Preserved the legacy preference without allowing it to re-enable resolution.
- Kept `AutoResolveStateConflicts` as a non-mutating compatibility no-op.
- Preserved conflict files, metadata, bytes, and modification times for manual review.
- Updated settings, localization, documentation, and changelog text to describe manual conflict handling.
- Added regression coverage for timestamp ordering, equal mtimes, clock skew, missing originals, nested paths, and legacy preference states.
- Rebuilt the XCFramework.
- Go and Xcode test suites pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->