### PR TITLE
fix(background): reject unverified continued completion (#146)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to VaultSync are documented here.
 
 ### Fixed
 
+- **Background sync no longer reports unfinished work as completed** ([#146](https://github.com/psimaker/vaultsync/issues/146)) — continued processing now reports success only after every expected vault is confirmed fully idle. If the sync engine stops, vault status cannot be read, a vault reports an error, the run expires or is cancelled, or the app returns to the foreground, the background run reports failure instead; conflict checks happen only after idle is proven.
 - **Conflicting Obsidian settings now wait for your decision** ([#145](https://github.com/psimaker/vaultsync/issues/145)) — VaultSync no longer automatically deletes, replaces, or promotes `.obsidian` conflict copies by modification time. The legacy preference stays stored but cannot re-enable the retired behavior, and detected conflicts remain visible for manual review. Syncthing's separate conflict-copy retention is not guaranteed.
 - **Keep Both no longer overwrites an existing conflict copy** ([#144](https://github.com/psimaker/vaultsync/issues/144)) — when the intended copy name is already occupied, VaultSync leaves all existing files untouched instead of replacing previously saved bytes.
 - **Manual conflict resolution preserves unrelated temporary files** ([#143](https://github.com/psimaker/vaultsync/issues/143)) — choosing the conflicting version no longer reuses or overwrites a pre-existing temporary file next to the note.

--- a/docs/decisions/029-continued-processing-success-requires-verified-idle.md
+++ b/docs/decisions/029-continued-processing-success-requires-verified-idle.md
@@ -3,6 +3,7 @@
 - Context: The continued-processing handler treated a stopped engine as success even when no readable folder snapshot proved completion (#146).
 - Decision: Success requires verified evidence at completion that every expected configured folder is idle with no pending work.
 - Decision: Engine death, an empty or unreadable snapshot, folder error, expiration, and cancellation are failures; foreground takeover is classified separately and never becomes idle success.
+- Decision: The expected folder set is captured from the first readable snapshot and never narrowed. A folder that disappears and a folder that appears are both failures, so no folder can vanish from the idle proof mid-run.
 - Decision: Conflict inspection runs only after verified idle and cannot upgrade the result; once terminal, late callbacks cannot overwrite it.
 - Why: Scheduler success is an evidence claim. A stopped engine or missing state proves only that observation ended, not that notes finished syncing.
 - Rejected alternative: Keep “engine stopped OR idle” as success, because crashes, expiration, and lifecycle transitions can all stop observation before work settles.

--- a/docs/decisions/029-continued-processing-success-requires-verified-idle.md
+++ b/docs/decisions/029-continued-processing-success-requires-verified-idle.md
@@ -1,0 +1,9 @@
+# 029 — Continued processing succeeds only on verified idle
+
+- Context: The continued-processing handler treated a stopped engine as success even when no readable folder snapshot proved completion (#146).
+- Decision: Success requires verified evidence at completion that every expected configured folder is idle with no pending work.
+- Decision: Engine death, an empty or unreadable snapshot, folder error, expiration, and cancellation are failures; foreground takeover is classified separately and never becomes idle success.
+- Decision: Conflict inspection runs only after verified idle and cannot upgrade the result; once terminal, late callbacks cannot overwrite it.
+- Why: Scheduler success is an evidence claim. A stopped engine or missing state proves only that observation ended, not that notes finished syncing.
+- Rejected alternative: Keep “engine stopped OR idle” as success, because crashes, expiration, and lifecycle transitions can all stop observation before work settles.
+- Links: issue [#146](https://github.com/psimaker/vaultsync/issues/146); `ios/VaultSync/Services/BackgroundSyncService.swift`; `ios/VaultSyncTests/BackgroundSyncServiceTests.swift`.

--- a/ios/VaultSync/Services/BackgroundSyncService.swift
+++ b/ios/VaultSync/Services/BackgroundSyncService.swift
@@ -44,6 +44,19 @@ enum BackgroundSyncService {
     /// tracks bridge ownership and is released early on `.background`.
     private static let sceneActiveLock = OSAllocatedUnfairLock(initialState: false)
 
+    /// Retains every system-delivered continued-processing handler until it
+    /// exits so foreground cancellation reaches the executing Swift task, not
+    /// only its pending scheduler request.
+    private struct ContinuedProcessingHandlerState: Sendable {
+        var nextToken: UInt64 = 0
+        var tasks: [UInt64: Task<Void, Never>] = [:]
+        var cancellationRequested = false
+    }
+
+    private static let continuedProcessingHandlerLock = OSAllocatedUnfairLock(
+        initialState: ContinuedProcessingHandlerState()
+    )
+
     static func setSceneActive(_ active: Bool) {
         sceneActiveLock.withLock { $0 = active }
     }
@@ -131,8 +144,7 @@ enum BackgroundSyncService {
         if #available(iOS 26.0, *) {
             let continuedHandler: @Sendable (BGTask) -> Void = { task in
                 guard let processingTask = task as? BGContinuedProcessingTask else { return }
-                let wrapped = UnsafeSendable(value: processingTask)
-                Task { await handleContinuedProcessing(task: wrapped.value) }
+                startContinuedProcessingHandler(task: processingTask)
             }
             continuedProcessingRegistered = BGTaskScheduler.shared.register(
                 forTaskWithIdentifier: continuedProcessingIdentifier,
@@ -301,6 +313,9 @@ enum BackgroundSyncService {
             )
 
             do {
+                continuedProcessingHandlerLock.withLock {
+                    $0.cancellationRequested = false
+                }
                 try BGTaskScheduler.shared.submit(request)
                 logger.info("Continued processing submitted")
             } catch {
@@ -314,6 +329,14 @@ enum BackgroundSyncService {
     /// Cancel pending continued processing task.
     @MainActor
     static func cancelContinuedProcessing() {
+        let executingTasks = continuedProcessingHandlerLock.withLock { state in
+            state.cancellationRequested = true
+            return Array(state.tasks.values)
+        }
+        for task in executingTasks {
+            task.cancel()
+        }
+
         guard continuedProcessingRegistered else { return }
         BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: continuedProcessingIdentifier)
     }
@@ -885,48 +908,308 @@ enum BackgroundSyncService {
 
     // MARK: - BGContinuedProcessingTask Handler
 
+    /// Pure #146 state machine. The live BGTask handler and deterministic tests
+    /// share this decision boundary; a terminal effect is emitted exactly once.
+    struct ContinuedProcessingRun: Sendable {
+        enum FolderSnapshot: Equatable, Sendable {
+            case unreadable
+            case readable(folderIDs: Set<String>, settlements: [String: FolderSettlement])
+        }
+
+        struct Observation: Equatable, Sendable {
+            let engineRunning: Bool
+            let sceneActive: Bool
+            let folders: FolderSnapshot
+        }
+
+        enum Event: Equatable, Sendable {
+            case observed(Observation)
+            case conflictInspectionFinished(token: UInt64, observation: Observation)
+            case expired(sceneActive: Bool)
+            case cancelled(sceneActive: Bool)
+        }
+
+        enum Failure: String, Equatable, Sendable {
+            case engineDied
+            case noFolders
+            case unreadableFolders
+            case folderError
+            case expectedFolderMissing
+            case folderSetChanged
+            case expired
+            case foregroundTakeover
+            case cancelled
+        }
+
+        enum Completion: Equatable, Sendable {
+            case success
+            case failure(Failure)
+
+            var isSuccessful: Bool {
+                self == .success
+            }
+
+            var logValue: String {
+                switch self {
+                case .success:
+                    return "success"
+                case let .failure(reason):
+                    return "failure-\(reason.rawValue)"
+                }
+            }
+        }
+
+        enum Effect: Equatable, Sendable {
+            case wait
+            case inspectConflicts(token: UInt64)
+            case complete(Completion)
+        }
+
+        private enum Phase: Equatable, Sendable {
+            case waiting
+            case inspectingConflicts(UInt64)
+            case terminal(Completion)
+        }
+
+        private var phase: Phase = .waiting
+        // Captured from the first readable observation and never narrowed: a
+        // folder disappearing mid-run cannot vanish from the success proof.
+        private var expectedFolderIDs: Set<String>?
+        private var nextConflictToken: UInt64 = 0
+
+        init() {}
+
+        var isTerminal: Bool {
+            if case .terminal = phase { return true }
+            return false
+        }
+
+        mutating func receive(_ event: Event) -> [Effect] {
+            if case .terminal = phase { return [] }
+            return receiveWhileActive(event)
+        }
+
+        private mutating func receiveWhileActive(_ event: Event) -> [Effect] {
+            switch event {
+            case let .observed(observation):
+                guard case .waiting = phase else { return [] }
+                return evaluate(observation, conflictInspectionCompleted: false)
+
+            case let .conflictInspectionFinished(token, observation):
+                guard case .inspectingConflicts(token) = phase else { return [] }
+                return evaluate(observation, conflictInspectionCompleted: true)
+
+            case let .expired(sceneActive):
+                return finish(.failure(sceneActive ? .foregroundTakeover : .expired))
+
+            case let .cancelled(sceneActive):
+                return finish(.failure(sceneActive ? .foregroundTakeover : .cancelled))
+            }
+        }
+
+        private mutating func evaluate(
+            _ observation: Observation,
+            conflictInspectionCompleted: Bool
+        ) -> [Effect] {
+            // Scene activation is the takeover signal. The lifecycle lock only
+            // controls who may stop the engine and can still be false while the
+            // foreground is attaching to an already-running instance.
+            if observation.sceneActive {
+                return finish(.failure(.foregroundTakeover))
+            }
+            if !observation.engineRunning {
+                return finish(.failure(.engineDied))
+            }
+
+            guard case let .readable(folderIDs, settlements) = observation.folders else {
+                return finish(.failure(.unreadableFolders))
+            }
+            if expectedFolderIDs == nil {
+                expectedFolderIDs = folderIDs
+            }
+            guard let expectedFolderIDs, !expectedFolderIDs.isEmpty else {
+                return finish(.failure(.noFolders))
+            }
+            guard expectedFolderIDs.isSubset(of: folderIDs) else {
+                return finish(.failure(.expectedFolderMissing))
+            }
+            guard folderIDs == expectedFolderIDs else {
+                return finish(.failure(.folderSetChanged))
+            }
+            guard expectedFolderIDs.isSubset(of: Set(settlements.keys)) else {
+                return finish(.failure(.unreadableFolders))
+            }
+
+            let expectedSettlements = expectedFolderIDs.compactMap { settlements[$0] }
+            if expectedSettlements.contains(.errored) {
+                return finish(.failure(.folderError))
+            }
+            guard expectedSettlements.allSatisfy({ $0 == .idle }) else {
+                phase = .waiting
+                return [.wait]
+            }
+
+            if conflictInspectionCompleted {
+                return finish(.success)
+            }
+            nextConflictToken &+= 1
+            phase = .inspectingConflicts(nextConflictToken)
+            return [.inspectConflicts(token: nextConflictToken)]
+        }
+
+        private mutating func finish(_ completion: Completion) -> [Effect] {
+            phase = .terminal(completion)
+            return [.complete(completion)]
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private static func startContinuedProcessingHandler(task: BGContinuedProcessingTask) {
+        let taskBox = UnsafeSendable(value: task)
+        continuedProcessingHandlerLock.withLock { state in
+            state.nextToken &+= 1
+            let token = state.nextToken
+            let handler = Task {
+                await handleContinuedProcessing(task: taskBox.value)
+                continuedProcessingHandlerLock.withLock { state in
+                    state.tasks[token] = nil
+                }
+            }
+            state.tasks[token] = handler
+            if state.cancellationRequested {
+                handler.cancel()
+            }
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private static func continuedProcessingCompletion(
+        in effects: [ContinuedProcessingRun.Effect]
+    ) -> ContinuedProcessingRun.Completion? {
+        guard let effect = effects.first,
+              case let .complete(completion) = effect else {
+            return nil
+        }
+        return completion
+    }
+
+    @available(iOS 26.0, *)
+    private static func completeContinuedProcessing(
+        _ completion: ContinuedProcessingRun.Completion,
+        task: BGContinuedProcessingTask
+    ) {
+        if completion.isSuccessful {
+            task.progress.completedUnitCount = 100
+        }
+        task.setTaskCompleted(success: completion.isSuccessful)
+        logger.info("Continued processing completed (result=\(completion.logValue, privacy: .public))")
+    }
+
+    private static func stopContinuedProcessingEngineIfBackgroundOwned() {
+        let foregroundOwnsLifecycle = lifecycleLock.withLock { $0.foregroundActive }
+        let sceneActive = isSceneActive()
+        guard !sceneActive, !foregroundOwnsLifecycle else {
+            logger.info("Continued processing termination skipped engine stop (foreground active)")
+            return
+        }
+        SyncBridgeService.stopSyncthing()
+        logger.info("Continued processing termination stopped Syncthing")
+    }
+
+    private static func continuedProcessingObservation() -> ContinuedProcessingRun.Observation {
+        let folders = continuedProcessingFolderSnapshot()
+        return ContinuedProcessingRun.Observation(
+            engineRunning: SyncBridgeService.isRunning(),
+            sceneActive: isSceneActive(),
+            folders: folders
+        )
+    }
+
     @available(iOS 26.0, *)
     private static func handleContinuedProcessing(task: BGContinuedProcessingTask) async {
         logger.info("Continued processing starting")
 
-        let expired = OSAllocatedUnfairLock(initialState: false)
+        let taskBox = UnsafeSendable(value: task)
+        let runLock = OSAllocatedUnfairLock(initialState: ContinuedProcessingRun())
 
         task.expirationHandler = {
-            expired.withLock { $0 = true }
-            let shouldStop = lifecycleLock.withLock { !$0.foregroundActive }
-            if shouldStop {
-                SyncBridgeService.stopSyncthing()
-                logger.info("Continued processing expired — Syncthing stopped")
-            } else {
-                logger.info("Continued processing expired — skipped stop (foreground active)")
+            let effects = runLock.withLock {
+                $0.receive(.expired(sceneActive: isSceneActive()))
             }
+            guard let completion = continuedProcessingCompletion(in: effects) else { return }
+            stopContinuedProcessingEngineIfBackgroundOwned()
+            completeContinuedProcessing(completion, task: taskBox.value)
         }
 
-        let progress = task.progress
-        progress.totalUnitCount = 100
+        let initialized = runLock.withLock { run in
+            guard !run.isTerminal else { return false }
+            taskBox.value.progress.totalUnitCount = 100
+            return true
+        }
+        if !initialized { return }
 
-        while !expired.withLock({ $0 }) {
-            try? await Task.sleep(for: .seconds(1))
-            guard !expired.withLock({ $0 }) else { break }
+        await withTaskCancellationHandler {
+            while true {
+                if Task.isCancelled { return }
 
-            let idle = allFoldersIdle()
-            if !SyncBridgeService.isRunning() || idle {
-                if idle {
-                    await notifyConflictsIfAny()
+                let observation = continuedProcessingObservation()
+                var transition = runLock.withLock { run -> (effects: [ContinuedProcessingRun.Effect], terminal: Bool) in
+                    let effects = run.receive(.observed(observation))
+                    return (effects, run.isTerminal)
                 }
-                progress.completedUnitCount = 100
-                task.setTaskCompleted(success: true)
-                logger.info("Continued processing completed")
-                return
+                if let completion = continuedProcessingCompletion(in: transition.effects) {
+                    completeContinuedProcessing(completion, task: task)
+                    return
+                }
+                if transition.terminal { return }
+
+                if let effect = transition.effects.first,
+                   case let .inspectConflicts(token) = effect {
+                    await notifyConflictsIfAny()
+                    let refreshedObservation = continuedProcessingObservation()
+                    transition = runLock.withLock { run in
+                        let effects = run.receive(.conflictInspectionFinished(
+                            token: token,
+                            observation: refreshedObservation
+                        ))
+                        return (effects, run.isTerminal)
+                    }
+                    if let completion = continuedProcessingCompletion(in: transition.effects) {
+                        completeContinuedProcessing(completion, task: task)
+                        return
+                    }
+                    if transition.terminal { return }
+                }
+
+                let pct = averageFolderCompletion()
+                let updatedProgress = runLock.withLock { run in
+                    guard !run.isTerminal else { return false }
+                    taskBox.value.progress.completedUnitCount = Int64(pct)
+                    taskBox.value.updateTitle(
+                        L10n.tr("Syncing Vault"),
+                        subtitle: L10n.fmt("%d%% complete", Int(pct))
+                    )
+                    return true
+                }
+                if !updatedProgress { return }
+
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    // `onCancel` owns the terminal failure and completion. Once
+                    // cancellation wakes this sleep, no later observation may
+                    // claim success.
+                    return
+                }
             }
-
-            let pct = averageFolderCompletion()
-            progress.completedUnitCount = Int64(pct)
-            task.updateTitle(L10n.tr("Syncing Vault"), subtitle: L10n.fmt("%d%% complete", Int(pct)))
+        } onCancel: {
+            let effects = runLock.withLock {
+                $0.receive(.cancelled(sceneActive: isSceneActive()))
+            }
+            guard let completion = continuedProcessingCompletion(in: effects) else { return }
+            stopContinuedProcessingEngineIfBackgroundOwned()
+            completeContinuedProcessing(completion, task: taskBox.value)
         }
-
-        task.setTaskCompleted(success: false)
-        logger.info("Continued processing expired")
     }
 
     // MARK: - Helpers
@@ -1142,6 +1425,32 @@ enum BackgroundSyncService {
             ))
         }
         return settlements
+    }
+
+    private static func continuedProcessingFolderSnapshot() -> ContinuedProcessingRun.FolderSnapshot {
+        let json = SyncBridgeService.getFoldersJSON()
+        guard let data = json.data(using: .utf8),
+              let folders = try? JSONDecoder().decode([FolderStub].self, from: data) else {
+            return .unreadable
+        }
+
+        let expectedFolderIDs = Set(folders.map(\.id))
+        var settlements: [String: FolderSettlement] = [:]
+        settlements.reserveCapacity(expectedFolderIDs.count)
+        for folder in folders {
+            let statusJSON = SyncBridgeService.getFolderStatusJSON(folderID: folder.id)
+            guard let statusData = statusJSON.data(using: .utf8),
+                  let status = try? JSONDecoder().decode(StatusStub.self, from: statusData) else {
+                continue
+            }
+            settlements[folder.id] = folderSettlement(
+                state: status.state,
+                needFiles: status.needFiles,
+                needBytes: status.needBytes,
+                inProgressBytes: status.inProgressBytes
+            )
+        }
+        return .readable(folderIDs: expectedFolderIDs, settlements: settlements)
     }
 
     private static func allFoldersIdle() -> Bool {

--- a/ios/VaultSyncTests/BackgroundSyncServiceTests.swift
+++ b/ios/VaultSyncTests/BackgroundSyncServiceTests.swift
@@ -66,3 +66,228 @@ struct FolderSettlementTests {
         #expect(BackgroundSyncService.folderSettlement(state: "error", needFiles: 12, needBytes: 9000, inProgressBytes: 1) == .errored)
     }
 }
+
+@Suite("Continued-processing completion (#146)")
+struct ContinuedProcessingCompletionTests {
+
+    typealias Run = BackgroundSyncService.ContinuedProcessingRun
+
+    private func observation(
+        engineRunning: Bool = true,
+        sceneActive: Bool = false,
+        folders: Run.FolderSnapshot
+    ) -> Run.Observation {
+        .init(
+            engineRunning: engineRunning,
+            sceneActive: sceneActive,
+            folders: folders
+        )
+    }
+
+    private func snapshot(
+        _ settlements: [String: BackgroundSyncService.FolderSettlement],
+        folderIDs: Set<String>? = nil
+    ) -> Run.FolderSnapshot {
+        .readable(
+            folderIDs: folderIDs ?? Set(settlements.keys),
+            settlements: settlements
+        )
+    }
+
+    @Test("Engine death without verified idle fails")
+    func issue146EngineDeathWithoutVerifiedIdleFails() {
+        var run = Run()
+
+        let effects = run.receive(.observed(.init(
+            engineRunning: false,
+            sceneActive: false,
+            folders: .unreadable
+        )))
+
+        #expect(effects == [.complete(.failure(.engineDied))])
+    }
+
+    @Test("All expected folders must remain idle through conflict inspection")
+    func issue146AllExpectedFoldersIdleSucceedsAfterConflictInspection() {
+        var run = Run()
+        let idle = observation(folders: snapshot([
+            "vault-a": .idle,
+            "vault-b": .idle,
+        ]))
+
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 1)])
+        #expect(
+            run.receive(.conflictInspectionFinished(token: 1, observation: idle))
+                == [.complete(.success)]
+        )
+        #expect(run.receive(.expired(sceneActive: false)).isEmpty)
+    }
+
+    @Test("Engine death during the wait is failure")
+    func issue146EngineDeathDuringWaitFails() {
+        var run = Run()
+        let active = observation(folders: snapshot(["vault-a": .active]))
+
+        #expect(run.receive(.observed(active)) == [.wait])
+        #expect(
+            run.receive(.observed(observation(
+                engineRunning: false,
+                folders: snapshot(["vault-a": .active])
+            ))) == [.complete(.failure(.engineDied))]
+        )
+    }
+
+    @Test("No configured folders is failure")
+    func issue146NoFoldersFails() {
+        var run = Run()
+
+        #expect(
+            run.receive(.observed(observation(
+                folders: snapshot([:], folderIDs: [])
+            ))) == [.complete(.failure(.noFolders))]
+        )
+    }
+
+    @Test("Unreadable folder list or status is failure")
+    func issue146UnreadableFolderEvidenceFails() {
+        var unreadableListRun = Run()
+        #expect(
+            unreadableListRun.receive(.observed(observation(folders: .unreadable)))
+                == [.complete(.failure(.unreadableFolders))]
+        )
+
+        var unreadableStatusRun = Run()
+        #expect(
+            unreadableStatusRun.receive(.observed(observation(
+                folders: snapshot([:], folderIDs: ["vault-a"])
+            ))) == [.complete(.failure(.unreadableFolders))]
+        )
+    }
+
+    @Test("Folder error is failure")
+    func issue146FolderErrorFails() {
+        var run = Run()
+
+        #expect(
+            run.receive(.observed(observation(
+                folders: snapshot(["vault-a": .errored])
+            ))) == [.complete(.failure(.folderError))]
+        )
+    }
+
+    @Test("Missing expected folder cannot disappear from the idle proof")
+    func issue146MissingExpectedFolderFails() {
+        var run = Run()
+        #expect(
+            run.receive(.observed(observation(folders: snapshot([
+                "vault-a": .active,
+                "vault-b": .active,
+            ])))) == [.wait]
+        )
+
+        #expect(
+            run.receive(.observed(observation(folders: snapshot([
+                "vault-a": .idle,
+            ])))) == [.complete(.failure(.expectedFolderMissing))]
+        )
+    }
+
+    @Test("A newly appearing folder invalidates the fixed proof set")
+    func issue146ChangedFolderSetFails() {
+        var run = Run()
+        #expect(
+            run.receive(.observed(observation(
+                folders: snapshot(["vault-a": .active])
+            ))) == [.wait]
+        )
+
+        #expect(
+            run.receive(.observed(observation(folders: snapshot([
+                "vault-a": .idle,
+                "vault-b": .idle,
+            ])))) == [.complete(.failure(.folderSetChanged))]
+        )
+    }
+
+    @Test("Expiration wins during conflict inspection and blocks late success")
+    func issue146ExpirationIsFailureAndLateConflictCallbackIsIgnored() {
+        var run = Run()
+        let idle = observation(folders: snapshot(["vault-a": .idle]))
+
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 1)])
+        #expect(
+            run.receive(.expired(sceneActive: false))
+                == [.complete(.failure(.expired))]
+        )
+        #expect(
+            run.receive(.conflictInspectionFinished(token: 1, observation: idle)).isEmpty
+        )
+    }
+
+    @Test("Foreground takeover is distinct from engine death")
+    func issue146ForegroundTakeoverFailsWithoutEngineDeathClassification() {
+        var run = Run()
+        let active = observation(folders: snapshot(["vault-a": .active]))
+
+        #expect(run.receive(.observed(active)) == [.wait])
+
+        #expect(
+            run.receive(.observed(observation(
+                engineRunning: true,
+                sceneActive: true,
+                folders: snapshot(["vault-a": .active])
+            ))) == [.complete(.failure(.foregroundTakeover))]
+        )
+    }
+
+    @Test("Cancellation wins during conflict inspection and blocks late success")
+    func issue146CancellationIsFailureAndLateConflictCallbackIsIgnored() {
+        var run = Run()
+        let idle = observation(folders: snapshot(["vault-a": .idle]))
+
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 1)])
+        #expect(
+            run.receive(.cancelled(sceneActive: false))
+                == [.complete(.failure(.cancelled))]
+        )
+        #expect(
+            run.receive(.conflictInspectionFinished(token: 1, observation: idle)).isEmpty
+        )
+    }
+
+    @Test("Conflict inspection starts only after idle and must revalidate idle")
+    func issue146ConflictInspectionCannotUpgradeUnverifiedWorkToSuccess() {
+        var run = Run()
+        let active = observation(folders: snapshot(["vault-a": .active]))
+        let idle = observation(folders: snapshot(["vault-a": .idle]))
+
+        #expect(run.receive(.observed(active)) == [.wait])
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 1)])
+        #expect(
+            run.receive(.conflictInspectionFinished(token: 1, observation: active))
+                == [.wait]
+        )
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 2)])
+        #expect(
+            run.receive(.conflictInspectionFinished(token: 2, observation: idle))
+                == [.complete(.success)]
+        )
+    }
+
+    @Test("Engine death during conflict inspection is still failure")
+    func issue146ConflictInspectionRechecksEngineLiveness() {
+        var run = Run()
+        let idle = observation(folders: snapshot(["vault-a": .idle]))
+
+        #expect(run.receive(.observed(idle)) == [.inspectConflicts(token: 1)])
+        #expect(
+            run.receive(.conflictInspectionFinished(
+                token: 1,
+                observation: observation(
+                    engineRunning: false,
+                    folders: snapshot(["vault-a": .idle])
+                )
+            )) == [.complete(.failure(.engineDied))]
+        )
+    }
+}


### PR DESCRIPTION
A stopped engine could previously report success without proving that every expected folder was idle.

Require readable, fixed-folder idle evidence before and after conflict inspection, and make engine death, expiration, cancellation, takeover, and folder failures terminal. The production-used state machine and issue- numbered tests prevent late callbacks from overwriting completion.

Fixes #146

<!-- PR titles follow Conventional Commits (feat:, fix:, docs:, chore:, ci: …);
     PRs are squash-merged, so the title becomes the commit subject on main. -->

## What & why
<!-- One or two sentences: what changes and why. Link the issue if there is one. -->

## Component(s)
- [ ] go (bridge / Syncthing)
- [ ] ios (app / widget)
- [ ] notify (relay)
- [ ] docs / CI

## Testing
- [ ] `cd go && make patch && go test -tags noassets ./bridge`
- [ ] `cd notify && go test ./...`
- [ ] iOS build / `xcodebuild test`
- [ ] Not applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Require verified idle evidence for every expected vault before reporting background sync success.
- Treat engine stops, empty or changing folder sets, missing or unreadable evidence, folder errors, expiration, cancellation, and foreground takeover as failures.
- Inspect conflicts only after idle verification and revalidate idle state afterward.
- Prevent late callbacks from overwriting terminal results.
- Coordinate task cancellation and background-owned engine cleanup.
- Add regression tests for completion, failure, cancellation, takeover, conflict revalidation, and engine death.
- Document the behavior in the changelog and decision record.

This prevents false background-sync success reports and reduces the risk of stale or incomplete sync results. It does not change public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->